### PR TITLE
Serve docs at lokf.nolan-nichols.com

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ ontology are all generated from that single source.
 
 > One sentence: *write OKF markdown, get a queryable knowledge graph for free.*
 
-**Documentation:** <https://www.nolan-nichols.com/lokf/>
+**Documentation:** <https://lokf.nolan-nichols.com/>
 
 ## Why
 

--- a/docs/CNAME
+++ b/docs/CNAME
@@ -1,0 +1,1 @@
+lokf.nolan-nichols.com

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -2,7 +2,7 @@ site_name: LOKF — Linked Open Knowledge Format
 site_description: >-
   A semantic profile of Google's Open Knowledge Format: write OKF markdown,
   get a queryable knowledge graph for free.
-site_url: https://www.nolan-nichols.com/lokf/
+site_url: https://lokf.nolan-nichols.com/
 repo_url: https://github.com/nicholsn/lokf
 repo_name: nicholsn/lokf
 edit_uri: edit/main/docs/


### PR DESCRIPTION
The personal-site repo (`nicholsn.github.io`) serves the apex/www domain `www.nolan-nichols.com`, and two repos can't share one Pages custom domain — so the docs move from the `/lokf/` subpath to their own subdomain.

- `mkdocs.yml` `site_url` → `https://lokf.nolan-nichols.com/`
- `docs/CNAME` so `mkdocs build` emits the `CNAME` file for the Pages custom domain
- README documentation link updated

### Manual steps to finish wiring (repo settings + DNS)
1. Add a DNS record: `lokf.nolan-nichols.com` **CNAME** → `nicholsn.github.io`.
2. In this repo's *Settings → Pages*, set the custom domain to `lokf.nolan-nichols.com`.

Context: the personal site ([nicholsn.github.io#1](https://github.com/nicholsn/nicholsn.github.io/pull/1)) links its LOKF references at this subdomain.