### PR TITLE
Prepare for PyPI publishing (metadata + Trusted Publishing workflow)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,51 @@
+name: publish
+
+# Publishes to PyPI via Trusted Publishing (OIDC) when a GitHub Release is
+# published — no API token is stored. Configure the trusted publisher once on
+# PyPI: project "lokf", owner "nicholsn", repo "lokf", workflow "publish.yml",
+# environment "pypi".
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+
+permissions: {}
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+      - uses: astral-sh/setup-uv@v5
+        with:
+          enable-cache: true
+
+      - name: Test (gate the release)
+        run: uv run --group dev pytest -q
+
+      - name: Build sdist + wheel
+        run: uv build
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: dist
+          path: dist/
+
+  publish:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: pypi
+      url: https://pypi.org/project/lokf/
+    permissions:
+      id-token: write # OIDC token for Trusted Publishing
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          name: dist
+          path: dist/
+
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1

--- a/README.md
+++ b/README.md
@@ -150,5 +150,6 @@ its open terms.
 
 ## License
 
-CC-BY-4.0 — see [`LICENSE`](LICENSE). It's a spec + vocabulary; if you'd rather put
-the scripts under a code license, swap in MIT or Apache-2.0.
+CC-BY-4.0 — see [`LICENSE`](https://github.com/nicholsn/lokf/blob/main/LICENSE).
+It's a spec + vocabulary; if you'd rather put the scripts under a code license,
+swap in MIT or Apache-2.0.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,10 +3,23 @@ name = "lokf"
 version = "0.1.0"
 description = "Linked Open Knowledge Format (LOKF) — a semantic profile of Google's Open Knowledge Format, defined once in LinkML"
 readme = "README.md"
-license = { text = "CC-BY-4.0" }
+license = "CC-BY-4.0"
+license-files = ["LICENSE"]
 authors = [{ name = "Nolan Nichols" }]
 requires-python = ">=3.11"
 keywords = ["linkml", "json-ld", "rdf", "knowledge-graph", "okf", "dcat", "prov", "sparql", "mcp"]
+classifiers = [
+    "Development Status :: 4 - Beta",
+    "Intended Audience :: Developers",
+    "Intended Audience :: Information Technology",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+    "Topic :: Software Development :: Libraries :: Python Modules",
+    "Topic :: Scientific/Engineering :: Information Analysis",
+    "Topic :: Text Processing :: Markup",
+]
 # Core toolkit: the `lokf` CLI, RDF conversion, the pyoxigraph store + SPARQL,
 # the local server, and the MCP server. Deliberately excludes linkml (heavy;
 # only the artifact regenerator needs it — see the `build` extra).


### PR DESCRIPTION
## Summary

Makes `lokf` publishable to PyPI and adds a tokenless release pipeline.

- **Metadata**: PEP 639 SPDX license expression (`CC-BY-4.0`) + `license-files`; PyPI classifiers (Development Status 4-Beta, audiences, Python 3.11–3.13, topics). README's `LICENSE` link made absolute so it renders on the PyPI page.
- **`.github/workflows/publish.yml`**: on a published GitHub Release, runs the test suite, builds sdist+wheel, and publishes to PyPI via **Trusted Publishing (OIDC)** — no API token is ever stored. Minimal permissions (`id-token: write` only on the publish job, gated behind a `pypi` environment).

## Verification

- `uv build` produces `lokf-0.1.0.tar.gz` + `lokf-0.1.0-py3-none-any.whl`; both **pass `twine check`**.
- sdist ships the packaged schema/context, the 5 agent skills, and cytoscape.js; wheel exposes `lokf`, `lokf-build`, `lokf-mcp`.
- `lokf` is available on PyPI (name unregistered).
- 118 tests pass (the workflow gates publish on them).

## Release procedure (after merge)

1. One-time on PyPI: add a **pending publisher** (project `lokf`, owner `nicholsn`, repo `lokf`, workflow `publish.yml`, environment `pypi`).
2. Cut a GitHub Release `v0.1.0` → the workflow tests, builds, and publishes automatically.