### PR TITLE
Serve docs at the lokf.nolan-nichols.com subdomain

### DIFF
--- a/web/astro.config.mjs
+++ b/web/astro.config.mjs
@@ -3,10 +3,9 @@ import { defineConfig } from "astro/config";
 import starlight from "@astrojs/starlight";
 import mermaid from "astro-mermaid";
 
-// The project site lives under /lokf on the custom domain.
+// Served at its own subdomain (no base path).
 export default defineConfig({
-  site: "https://www.nolan-nichols.com",
-  base: "/lokf",
+  site: "https://lokf.nolan-nichols.com",
   integrations: [
     // Renders ```mermaid fences client-side, synced to the Starlight theme.
     // Must precede starlight() so it can hook Expressive Code.

--- a/web/public/CNAME
+++ b/web/public/CNAME
@@ -1,0 +1,1 @@
+lokf.nolan-nichols.com

--- a/web/src/content/docs/getting-started.mdx
+++ b/web/src/content/docs/getting-started.mdx
@@ -67,7 +67,7 @@ You can also run the individual generators by hand:
 
 <ValidateBundle />
 
-See [Validation](/lokf/guide/validation/) for the JSON Schema / SHACL split.
+See [Validation](/guide/validation/) for the JSON Schema / SHACL split.
 
 ## Markdown → RDF in one command
 
@@ -77,8 +77,8 @@ directly from the checkout you just cloned:
 <QuickstartRdf />
 
 This is the whole thesis: OKF authoring in, RDF knowledge graph out. The
-[Convert](/lokf/toolkit/convert/) page covers every format and flag, and the
-mechanics of the projection are in [Markdown to RDF](/lokf/guide/markdown-to-rdf/).
+[Convert](/toolkit/convert/) page covers every format and flag, and the
+mechanics of the projection are in [Markdown to RDF](/guide/markdown-to-rdf/).
 
 ## Work on the docs
 

--- a/web/src/content/docs/guide/concepts.mdx
+++ b/web/src/content/docs/guide/concepts.mdx
@@ -67,5 +67,5 @@ OKF meaning. The body is mapped to `schema:text` in the RDF projection.
 
 ## Next
 
-- Give links meaning with [typed relationships](/lokf/guide/relationships/).
-- Pick the right class from the [type vocabulary](/lokf/guide/types/).
+- Give links meaning with [typed relationships](/guide/relationships/).
+- Pick the right class from the [type vocabulary](/guide/types/).

--- a/web/src/content/docs/guide/markdown-to-rdf.mdx
+++ b/web/src/content/docs/guide/markdown-to-rdf.mdx
@@ -35,7 +35,7 @@ the meaning.
 ## Worked example
 
 The frontmatter of the reference bundle's WAU metric (abridged — see the
-[full file](/lokf/examples/#one-concept-end-to-end)), and the triples it
+[full file](/examples/#one-concept-end-to-end)), and the triples it
 expands to:
 
 <Tabs>
@@ -74,5 +74,5 @@ You never have to wire the context by hand — `lokf convert` (and the
 
 <QuickstartRdf />
 
-See [Convert](/lokf/toolkit/convert/) for the full command, every output
+See [Convert](/toolkit/convert/) for the full command, every output
 format, and the matching `just` recipe.

--- a/web/src/content/docs/guide/validation.mdx
+++ b/web/src/content/docs/guide/validation.mdx
@@ -55,4 +55,4 @@ As in OKF, missing optional fields, unknown `type` values, unknown
 frontmatter keys, and broken cross-links MUST NOT cause rejection.
 :::
 
-The normative text lives in the [specification](/lokf/specification/).
+The normative text lives in the [specification](/specification/).

--- a/web/src/content/docs/index.mdx
+++ b/web/src/content/docs/index.mdx
@@ -6,10 +6,10 @@ hero:
   tagline: A semantic profile of Google's Open Knowledge Format — write OKF markdown, get a queryable knowledge graph for free.
   actions:
     - text: Get started
-      link: /lokf/getting-started/
+      link: /getting-started/
       icon: right-arrow
     - text: Explore the graph
-      link: /lokf/graph/
+      link: /graph/
       icon: external
       variant: minimal
     - text: View on GitHub

--- a/web/src/content/docs/reference/artifacts.mdx
+++ b/web/src/content/docs/reference/artifacts.mdx
@@ -51,7 +51,7 @@ textual diff with no semantic change — the graphs stay isomorphic.
 
 ## What the build does
 
-The [`lokf-build`](/lokf/reference/api/) console script chains four steps: generate the
+The [`lokf-build`](/reference/api/) console script chains four steps: generate the
 artifacts above, assemble `examples/acme-knowledge/` into a single
 `KnowledgeBundle` document, validate it with `linkml-validate`, and project it
 to N-Triples in `examples/`.

--- a/web/src/content/docs/toolkit/agents.mdx
+++ b/web/src/content/docs/toolkit/agents.mdx
@@ -7,7 +7,7 @@ sidebar:
 
 import { Tabs, TabItem } from "@astrojs/starlight/components";
 
-Beyond the [MCP server](/lokf/toolkit/mcp/), LOKF bundles a set of **agent skills** —
+Beyond the [MCP server](/toolkit/mcp/), LOKF bundles a set of **agent skills** —
 self-contained instructions that teach a coding agent (Claude Code and
 compatible harnesses) how to work with LOKF bundles. They ship inside the
 `lokf` package, so `uv pip install lokf` puts them one command away.
@@ -72,5 +72,5 @@ That gives you:
 The core install is lean — `typer`, `rdflib`, `pyoxigraph`, and `mcp`. Only
 regenerating the LinkML-derived artifacts needs the heavier `linkml`
 dependency, which lives behind the `lokf[build]` extra (`uv pip install
-'lokf[build]'`). See [Getting started](/lokf/getting-started/) for the
+'lokf[build]'`). See [Getting started](/getting-started/) for the
 from-source setup.

--- a/web/src/content/docs/toolkit/convert.md
+++ b/web/src/content/docs/toolkit/convert.md
@@ -6,7 +6,7 @@ sidebar:
 ---
 
 `lokf convert` projects LOKF markdown to RDF. It is the CLI in front of
-[`lokf.rdf.serialize`](/lokf/reference/api/): attach the generated context,
+[`lokf.rdf.serialize`](/reference/api/): attach the generated context,
 expand the JSON-LD, and emit triples — no glue code on your side.
 
 ```bash
@@ -81,5 +81,5 @@ g = rdf.graph_of("examples/acme-knowledge/metrics/weekly-active-users.md")
 len(g)
 ```
 
-See [Markdown to RDF](/lokf/guide/markdown-to-rdf/) for the mechanics of the
-projection, and [Query](/lokf/toolkit/query/) to run SPARQL over the result.
+See [Markdown to RDF](/guide/markdown-to-rdf/) for the mechanics of the
+projection, and [Query](/toolkit/query/) to run SPARQL over the result.

--- a/web/src/content/docs/toolkit/index.mdx
+++ b/web/src/content/docs/toolkit/index.mdx
@@ -12,28 +12,28 @@ need to **load** a bundle, **inspect** the vocabulary, **project** markdown to
 RDF, **query** it with SPARQL, **serve** it locally, **propose** typed
 relations from prose links, and **export** the result as a graph or as
 schema.org JSON-LD. It comes with a CLI (`lokf convert` / `query` / `serve` /
-`propose` / `vocab` / `skills` / `mcp`) and an [MCP server](/lokf/toolkit/mcp/) so agents
+`propose` / `vocab` / `skills` / `mcp`) and an [MCP server](/toolkit/mcp/) so agents
 can drive all of it. The format itself stays where it belongs — in `lokf.yaml`
-and the [specification](/lokf/specification/); the toolkit never hardcodes a
+and the [specification](/specification/); the toolkit never hardcodes a
 type or predicate it can read from the schema.
 
 | Module | What it gives you |
 |---|---|
 | `lokf.model` | `load_bundle()` → `Bundle` / `Concept` objects, JSON-LD and `rdflib.Graph` projection |
-| `lokf.rdf` | `serialize()` / `graph_of()` — project markdown to RDF ([`lokf convert`](/lokf/toolkit/convert/)) |
-| `lokf.store` | `GraphStore` — an in-memory pyoxigraph store for SPARQL ([`lokf query`](/lokf/toolkit/query/)) |
-| `lokf.server` | `serve()` — a local SPARQL endpoint + graph explorer ([`lokf serve`](/lokf/toolkit/serve/)) |
+| `lokf.rdf` | `serialize()` / `graph_of()` — project markdown to RDF ([`lokf convert`](/toolkit/convert/)) |
+| `lokf.store` | `GraphStore` — an in-memory pyoxigraph store for SPARQL ([`lokf query`](/toolkit/query/)) |
+| `lokf.server` | `serve()` — a local SPARQL endpoint + graph explorer ([`lokf serve`](/toolkit/serve/)) |
 | `lokf.schema` | `vocabulary()` → the typed-relation slots and `RelationType` vocabulary, straight from `lokf.yaml` |
 | `lokf.parse` | frontmatter parsing helpers (`parse_concept`, `isoify`) |
-| `lokf.propose` | heuristic [relation proposer](/lokf/toolkit/proposer/) + the `lokf propose` CLI |
+| `lokf.propose` | heuristic [relation proposer](/toolkit/proposer/) + the `lokf propose` CLI |
 | `lokf.export` | Cytoscape.js graph elements and schema.org `Dataset` JSON-LD |
-| `lokf.mcp_server` | the `lokf mcp` / `lokf-mcp` [MCP server](/lokf/toolkit/mcp/) that exposes the toolkit to agents |
+| `lokf.mcp_server` | the `lokf mcp` / `lokf-mcp` [MCP server](/toolkit/mcp/) that exposes the toolkit to agents |
 | `lokf.build` | the `lokf-build` console script that regenerates every artifact |
 
 ## Install
 
-Installing `lokf` gives you the CLI (`lokf`), the [MCP server](/lokf/toolkit/mcp/)
-(`lokf-mcp`), and the bundled [agent skills](/lokf/toolkit/agents/):
+Installing `lokf` gives you the CLI (`lokf`), the [MCP server](/toolkit/mcp/)
+(`lokf-mcp`), and the bundled [agent skills](/toolkit/agents/):
 
 <Tabs>
   <TabItem label="uv">
@@ -64,12 +64,12 @@ uv pip install 'lokf[build]'   # adds linkml for lokf-build
 
 Working inside a clone of this repository? `uv sync` already installs the
 package (with the `build` extra) in editable mode — see
-[Getting started](/lokf/getting-started/).
+[Getting started](/getting-started/).
 
 ## A five-minute tour
 
 Everything below runs against the committed
-[reference bundle](/lokf/examples/), from the repository root:
+[reference bundle](/examples/), from the repository root:
 
 ```python
 import lokf
@@ -118,11 +118,11 @@ outside a repo checkout.
 
 - **Build your own knowledge base** — from an empty directory to a validated,
   queryable bundle: authoring, validation, proposals, RDF, and a graph view.
-  See the [Tutorial](/lokf/toolkit/tutorial/).
+  See the [Tutorial](/toolkit/tutorial/).
 - **Relation proposer** — how `lokf propose` turns prose links into
   typed-relation suggestions, and where its heuristics stop. See the
-  [Proposer](/lokf/toolkit/proposer/).
+  [Proposer](/toolkit/proposer/).
 - **Knowledge graph** — the reference bundle rendered as an interactive graph,
-  built with `lokf.export`. See the [Knowledge graph](/lokf/graph/).
+  built with `lokf.export`. See the [Knowledge graph](/graph/).
 - **Python reference** — generated API docs for every module in the package.
-  See the [API reference](/lokf/reference/api/).
+  See the [API reference](/reference/api/).

--- a/web/src/content/docs/toolkit/mcp.md
+++ b/web/src/content/docs/toolkit/mcp.md
@@ -89,4 +89,4 @@ base with no bespoke code:
   class is allowed to use.
 
 For the skills that package these workflows for coding agents, see
-[Agents](/lokf/toolkit/agents/).
+[Agents](/toolkit/agents/).

--- a/web/src/content/docs/toolkit/proposer.md
+++ b/web/src/content/docs/toolkit/proposer.md
@@ -5,7 +5,7 @@ sidebar:
   order: 5
 ---
 
-LOKF keeps [two layers in one file](/lokf/guide/relationships/): human-facing
+LOKF keeps [two layers in one file](/guide/relationships/): human-facing
 markdown links in the body, and typed frontmatter fields that carry the
 *kind* of link. In practice the prose layer always runs ahead — you write
 `derived from [Orders](/datasets/orders.md)` long before you remember to add
@@ -37,10 +37,10 @@ applied = apply(proposals, min_confidence=0.5)   # round-trips the files
 
 Each `Proposal` carries the **source** concept, the prose **link** (text,
 target, and the sentence it sits in), the suggested **relation** (a
-`Relation` from the [vocabulary](/lokf/reference/api/)), a **confidence**
+`Relation` from the [vocabulary](/reference/api/)), a **confidence**
 score, and a **rationale** — the evidence, so you can judge the suggestion
 without opening the file. See the proposer in action in the
-[tutorial](/lokf/toolkit/tutorial/#4-propose-typed-relations).
+[tutorial](/toolkit/tutorial/#4-propose-typed-relations).
 
 ## How the heuristics work
 
@@ -61,7 +61,7 @@ matched against a priority-ordered table of cue patterns: wording like
 (`dcterms:requires`), *measures / counts* at `measures`, *part of / within*
 at `isPartOf`, *same as / alias* at `sameAs`, *attributed to / authored by*
 at `wasAttributedTo`, *joins with / joined on* at `joinsWith`, and so on
-across the [relation vocabulary](/lokf/guide/relationships/). The first row
+across the [relation vocabulary](/guide/relationships/). The first row
 that matches
 (and whose relation the source's type may carry) wins. A link whose sentence
 matches no cue at all falls back to a low-confidence `relatedTo` — the
@@ -119,7 +119,7 @@ untouched. Where a proposal lands depends on the relation:
   target's IRI appended to the list.
 - **Reified `relations:` entry** — predicates from the `RelationType`
   vocabulary that have no dedicated field (`joinsWith`, `wasAttributedTo`)
-  are written as [reified relations](/lokf/guide/relationships/#custom-predicates-relations):
+  are written as [reified relations](/guide/relationships/#custom-predicates-relations):
 
   ```yaml
   relations:
@@ -130,10 +130,10 @@ untouched. Where a proposal lands depends on the relation:
 The two forms do **not** project to identical RDF. A named slot becomes a
 direct triple with its bound predicate
 (`<metric> prov:wasDerivedFrom <dataset>`); a `relations:` entry projects as
-a [reified statement](/lokf/guide/relationships/#custom-predicates-relations)
+a [reified statement](/guide/relationships/#custom-predicates-relations)
 — an `rdf:Statement` node reached via `lokf:relations` that carries the
 predicate and target — not a direct triple. The
-[knowledge-graph page](/lokf/graph/) flattens reified entries back into
+[knowledge-graph page](/graph/) flattens reified entries back into
 labeled edges for display, so both forms look the same in the picture, but
 SPARQL over `bundle.graph()` sees the difference.
 

--- a/web/src/content/docs/toolkit/query.mdx
+++ b/web/src/content/docs/toolkit/query.mdx
@@ -8,7 +8,7 @@ sidebar:
 import { Tabs, TabItem } from "@astrojs/starlight/components";
 
 `lokf query` loads a bundle into an in-memory
-[`GraphStore`](/lokf/reference/api/) (backed by pyoxigraph) and runs SPARQL over
+[`GraphStore`](/reference/api/) (backed by pyoxigraph) and runs SPARQL over
 it. Nothing is written; the store lives only for the length of the command.
 
 ```bash
@@ -93,7 +93,7 @@ just query examples/acme-knowledge 'SELECT ?s WHERE { ?s a lokf:Metric }'
 
 ## From Python
 
-`lokf query` is a wrapper around [`GraphStore`](/lokf/reference/api/). The store
+`lokf query` is a wrapper around [`GraphStore`](/reference/api/). The store
 gives you the same queries, plus `rdflib_graph()`, `serialize_results()`, and
 `dump()`:
 
@@ -111,4 +111,4 @@ store.construct("CONSTRUCT { ?s ?p ?o } WHERE { ?s a lokf:Metric ; ?p ?o }")
 ```
 
 The prefixes are preset on the store too — `store.prefixes` is the dict it
-prepends. To publish the same store over HTTP, see [Serve](/lokf/toolkit/serve/).
+prepends. To publish the same store over HTTP, see [Serve](/toolkit/serve/).

--- a/web/src/content/docs/toolkit/serve.md
+++ b/web/src/content/docs/toolkit/serve.md
@@ -7,7 +7,7 @@ sidebar:
 
 `lokf serve` publishes a bundle locally as a **SPARQL endpoint** plus a **live
 graph explorer** — the reference bundle you see on the [Knowledge
-graph](/lokf/graph/) page, served from your own checkout.
+graph](/graph/) page, served from your own checkout.
 
 ```bash
 uv run lokf serve examples/acme-knowledge
@@ -43,7 +43,7 @@ curl -s 'http://127.0.0.1:8000/sparql' \
 ```
 
 The schema prefixes are preset here exactly as they are for
-[`lokf query`](/lokf/toolkit/query/), so your query needs no `PREFIX` block.
+[`lokf query`](/toolkit/query/), so your query needs no `PREFIX` block.
 
 ## Fully offline
 

--- a/web/src/content/docs/toolkit/tutorial.mdx
+++ b/web/src/content/docs/toolkit/tutorial.mdx
@@ -7,15 +7,15 @@ sidebar:
 
 import { Tabs, TabItem } from "@astrojs/starlight/components";
 
-The [reference bundle](/lokf/examples/) shows the destination; this tutorial
+The [reference bundle](/examples/) shows the destination; this tutorial
 walks the road. Starting from an empty directory you will author a
-three-concept bundle, validate it, let the [proposer](/lokf/toolkit/proposer/) upgrade
+three-concept bundle, validate it, let the [proposer](/toolkit/proposer/) upgrade
 your prose links into typed relations, and end with an RDF graph you can
 query and visualize.
 
 Every command below is copy-pasteable and assumes a clone of this repository
 (`git clone https://github.com/nicholsn/lokf.git && cd lokf && uv sync` — see
-[Getting started](/lokf/getting-started/)), run from the repository root so
+[Getting started](/getting-started/)), run from the repository root so
 `lokf.yaml` is in reach of the validator.
 
 ## 1. Create the bundle root
@@ -161,7 +161,7 @@ uv run linkml-validate -s lokf.yaml -C Metric metric.json
 </TabItem>
 </Tabs>
 
-See [Validation](/lokf/guide/validation/) for the JSON Schema / SHACL split.
+See [Validation](/guide/validation/) for the JSON Schema / SHACL split.
 
 ## 4. Propose typed relations
 
@@ -221,13 +221,13 @@ round-trip YAML editor, so your comments, ordering, and formatting survive.
 ```
 
 The prose is untouched — body links stay for humans, the frontmatter now
-carries the machine-readable layer. [How the heuristics work](/lokf/toolkit/proposer/)
+carries the machine-readable layer. [How the heuristics work](/toolkit/proposer/)
 covers cue phrases, domains, confidence, and the limits.
 
 ## 5. Project to RDF
 
 Load the bundle and serialize the graph — same two calls as the
-[five-minute tour](/lokf/toolkit/#a-five-minute-tour):
+[five-minute tour](/toolkit/#a-five-minute-tour):
 
 ```bash
 uv run python - <<'EOF'
@@ -261,11 +261,11 @@ Three markdown files, 23 triples, real edges (abridged):
 
 From here it's standard RDF tooling: SPARQL over `bundle.graph()`, SHACL with
 the generated shapes, OWL reasoning — see
-[Markdown to RDF](/lokf/guide/markdown-to-rdf/).
+[Markdown to RDF](/guide/markdown-to-rdf/).
 
 ## 6. Visualize it
 
-The [Knowledge graph](/lokf/graph/) page on this site is the pattern to copy:
+The [Knowledge graph](/graph/) page on this site is the pattern to copy:
 `lokf.export.to_cytoscape()` turns a bundle into Cytoscape.js elements whose
 edges are the RDF predicates from your typed relations (CURIE-labeled —
 `prov:wasDerivedFrom`, `lokf:measures`, …); plain body hyperlinks are
@@ -281,10 +281,10 @@ json.dump(to_cytoscape(bundle), open("graph.json", "w"), indent=2)
 EOF
 ```
 
-Or skip the file entirely: [`lokf serve mykb/`](/lokf/toolkit/serve/) publishes
+Or skip the file entirely: [`lokf serve mykb/`](/toolkit/serve/) publishes
 a live graph explorer (and a SPARQL endpoint) for your bundle with no build
 step. This documentation site uses the same projection — the
-[`lokf export`](/lokf/reference/api/) command emits `graph.json` and the
+[`lokf export`](/reference/api/) command emits `graph.json` and the
 schema.org `Dataset` JSON-LD (from `lokf.export.dataset_search_jsonld()`) that
 its knowledge-graph page and `<head>` consume, so your datasets are
 discoverable by search engines.


### PR DESCRIPTION
Switches the Astro docs from `www.nolan-nichols.com/lokf/` to the dedicated **`lokf.nolan-nichols.com`** subdomain (DNS already pointed at GitHub Pages).

- `astro.config`: `site` → the subdomain, `base` dropped (clean root paths).
- `web/public/CNAME` added so the Pages deploy configures the custom domain.
- All 52 internal `/lokf/...` links + 2 hero actions rewritten to `/...`; GitHub URLs untouched.

Verified: build green (21 pages), graph island fetches `/graph.json`, all 20 internal page links resolve, canonical/sitemap on the subdomain.