### PR TITLE
Update docs URL to the subdomain (README + pyproject)

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ ontology are all generated from that single source.
 
 > One sentence: *write OKF markdown, get a queryable knowledge graph for free.*
 
-**Documentation:** <https://www.nolan-nichols.com/lokf/>
+**Documentation:** <https://lokf.nolan-nichols.com/>
 
 ## Why
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,7 +40,7 @@ build = [
 ]
 
 [project.urls]
-Documentation = "https://www.nolan-nichols.com/lokf/"
+Documentation = "https://lokf.nolan-nichols.com/"
 Repository = "https://github.com/nicholsn/lokf"
 Issues = "https://github.com/nicholsn/lokf/issues"
 


### PR DESCRIPTION
Follow-up to the subdomain switch: point the README documentation link and the package Documentation URL at https://lokf.nolan-nichols.com/ (the old www.nolan-nichols.com/lokf/ now 301-redirects there). Ships in the next PyPI release.