### PR TITLE
Graph explorer: fcose layout + fullscreen; compact-Turtle worked example

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -286,20 +286,30 @@ dependsOn:     [ https://acme.example/knowledge/glossary/active-user ]
 ```
 <!-- --8<-- [end:worked-yaml] -->
 
-Attaching the context and expanding yields (N-Triples, abridged):
+Attaching the context and expanding yields (Turtle, abridged):
 
 <!-- --8<-- [start:worked-ttl] -->
 ```turtle
-<…/metrics/weekly-active-users> a lokf:Metric .
-<…/metrics/weekly-active-users> schema:name "Weekly Active Users" .
-<…/metrics/weekly-active-users> schema:unitText "users" .
-<…/metrics/weekly-active-users> schema:keywords "growth", "engagement" .
-<…/metrics/weekly-active-users> schema:dateModified "2026-06-30T12:00:00Z"^^xsd:dateTime .
-<…/metrics/weekly-active-users> schema:author <…/people/jsmith> .
-<…/people/jsmith> a schema:Person ; schema:name "Jordan Smith" .
-<…/metrics/weekly-active-users> lokf:measures  <…/glossary/active-user> .
-<…/metrics/weekly-active-users> prov:wasDerivedFrom <…/tables/user-events> .
-<…/metrics/weekly-active-users> dcterms:requires <…/glossary/active-user> .
+@prefix lokf:    <https://w3id.org/lokf/> .
+@prefix schema:  <http://schema.org/> .
+@prefix prov:    <http://www.w3.org/ns/prov#> .
+@prefix dcterms: <http://purl.org/dc/terms/> .
+@prefix xsd:     <http://www.w3.org/2001/XMLSchema#> .
+
+<…/metrics/weekly-active-users>
+    a lokf:Metric ;
+    schema:name "Weekly Active Users" ;
+    schema:unitText "users" ;
+    schema:keywords "growth", "engagement" ;
+    schema:dateModified "2026-06-30T12:00:00Z"^^xsd:dateTime ;
+    schema:author <…/people/jsmith> ;
+    lokf:measures <…/glossary/active-user> ;
+    prov:wasDerivedFrom <…/tables/user-events> ;
+    dcterms:requires <…/glossary/active-user> .
+
+<…/people/jsmith>
+    a schema:Person ;
+    schema:name "Jordan Smith" .
 ```
 <!-- --8<-- [end:worked-ttl] -->
 

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -12,12 +12,12 @@
         "astro": "^7.0.2",
         "astro-mermaid": "^2.1.0",
         "cytoscape": "^3.34.0",
+        "cytoscape-fcose": "^2.2.0",
         "mermaid": "^11.16.0",
         "sharp": "^0.34.5"
       },
       "devDependencies": {
-        "@types/cytoscape": "^3.21.9",
-        "rehype-mermaid": "^3.0.0"
+        "@types/cytoscape": "^3.21.9"
       }
     },
     "node_modules/@antfu/install-pkg": {
@@ -1113,16 +1113,6 @@
       "license": "MIT",
       "dependencies": {
         "@expressive-code/core": "^0.44.0"
-      }
-    },
-    "node_modules/@fortawesome/fontawesome-free": {
-      "version": "6.7.2",
-      "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-free/-/fontawesome-free-6.7.2.tgz",
-      "integrity": "sha512-JUOtgFW6k9u4Y+xeIaEiLr3+cjoUPiAuLXoyKOJSia6Duzb7pq+A76P9ZdPDoAoxHdHzq6gE9/jKBGXlZT8FbA==",
-      "dev": true,
-      "license": "(CC-BY-4.0 AND OFL-1.1 AND MIT)",
-      "engines": {
-        "node": ">=6"
       }
     },
     "node_modules/@iconify/types": {
@@ -4209,22 +4199,6 @@
         "url": "https://opencollective.com/unified"
       }
     },
-    "node_modules/hast-util-from-dom": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/hast-util-from-dom/-/hast-util-from-dom-5.0.1.tgz",
-      "integrity": "sha512-N+LqofjR2zuzTjCPzyDUdSshy4Ma6li7p/c3pA78uTwzFgENbgbUrm2ugwsOdcjI1muO+o6Dgzp9p8WHtn/39Q==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "@types/hast": "^3.0.0",
-        "hastscript": "^9.0.0",
-        "web-namespaces": "^2.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
     "node_modules/hast-util-from-html": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/hast-util-from-html/-/hast-util-from-html-2.0.3.tgz",
@@ -4237,23 +4211,6 @@
         "parse5": "^7.0.0",
         "vfile": "^6.0.0",
         "vfile-message": "^4.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/hast-util-from-html-isomorphic": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/hast-util-from-html-isomorphic/-/hast-util-from-html-isomorphic-2.0.0.tgz",
-      "integrity": "sha512-zJfpXq44yff2hmE0XmwEOzdWin5xwH+QIhMLOScpX91e/NSGPsAzNCvLQDIEPyO2TXi+lBmU6hjLIhV8MwP2kw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/hast": "^3.0.0",
-        "hast-util-from-dom": "^5.0.0",
-        "hast-util-from-html": "^2.0.0",
-        "unist-util-remove-position": "^5.0.0"
       },
       "funding": {
         "type": "opencollective",
@@ -5558,29 +5515,6 @@
         "uuid": "^11.1.0 || ^12 || ^13 || ^14.0.0"
       }
     },
-    "node_modules/mermaid-isomorphic": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/mermaid-isomorphic/-/mermaid-isomorphic-3.1.0.tgz",
-      "integrity": "sha512-mzrvfEVjnJIkJlEqxp3eMuR1wS0TeLCH1VK5E/T5yzWaBwI3JqjJuw70yUIThSCDJ5bRs6O3rgfp00oBAbvSeQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@fortawesome/fontawesome-free": "^6.0.0",
-        "katex": "^0.16.0",
-        "mermaid": "^11.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/remcohaszing"
-      },
-      "peerDependencies": {
-        "playwright": "1"
-      },
-      "peerDependenciesMeta": {
-        "playwright": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/micromark": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/micromark/-/micromark-4.0.2.tgz",
@@ -6317,16 +6251,6 @@
       ],
       "license": "MIT"
     },
-    "node_modules/mini-svg-data-uri": {
-      "version": "1.4.4",
-      "resolved": "https://registry.npmjs.org/mini-svg-data-uri/-/mini-svg-data-uri-1.4.4.tgz",
-      "integrity": "sha512-r9deDe9p5FJUPZAk3A59wGH7Ii9YrjjWw0jmw/liSbHl2CHiyXj6FcDXDu2K3TjVAXqiJdaw3xxwlZZr9E6nHg==",
-      "dev": true,
-      "license": "MIT",
-      "bin": {
-        "mini-svg-data-uri": "cli.js"
-      }
-    },
     "node_modules/mrmime": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/mrmime/-/mrmime-2.0.1.tgz",
@@ -6871,35 +6795,6 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/rehype-mermaid": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/rehype-mermaid/-/rehype-mermaid-3.0.0.tgz",
-      "integrity": "sha512-fxrD5E4Fa1WXUjmjNDvLOMT4XB1WaxcfycFIWiYU0yEMQhcTDElc9aDFnbDFRLxG1Cfo1I3mfD5kg4sjlWaB+Q==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/hast": "^3.0.0",
-        "hast-util-from-html-isomorphic": "^2.0.0",
-        "hast-util-to-text": "^4.0.0",
-        "mermaid-isomorphic": "^3.0.0",
-        "mini-svg-data-uri": "^1.0.0",
-        "space-separated-tokens": "^2.0.0",
-        "unified": "^11.0.0",
-        "unist-util-visit-parents": "^6.0.0",
-        "vfile": "^6.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/remcohaszing"
-      },
-      "peerDependencies": {
-        "playwright": "1"
-      },
-      "peerDependenciesMeta": {
-        "playwright": {
-          "optional": true
-        }
       }
     },
     "node_modules/rehype-parse": {

--- a/web/package.json
+++ b/web/package.json
@@ -20,6 +20,7 @@
     "astro": "^7.0.2",
     "astro-mermaid": "^2.1.0",
     "cytoscape": "^3.34.0",
+    "cytoscape-fcose": "^2.2.0",
     "mermaid": "^11.16.0",
     "sharp": "^0.34.5"
   },

--- a/web/scripts/sync-content.mjs
+++ b/web/scripts/sync-content.mjs
@@ -56,8 +56,9 @@ writePartial(
 );
 writePartial(
   "metric-nt",
+  // N-Triples is a subset of Turtle, so the `turtle` grammar highlights it.
   fenced(
-    'text title="examples/weekly-active-users.nt"',
+    'turtle title="examples/weekly-active-users.nt"',
     read("examples/weekly-active-users.nt"),
   ),
 );

--- a/web/src/components/KnowledgeGraph.astro
+++ b/web/src/components/KnowledgeGraph.astro
@@ -26,6 +26,19 @@
     </div>
   </div>
   <div class="lokf-graph__stage">
+    <div class="lokf-graph__toolbar">
+      <button type="button" class="lokf-graph__btn" data-action="fit" title="Fit graph to view">
+        ⤢ Fit
+      </button>
+      <button
+        type="button"
+        class="lokf-graph__btn"
+        data-action="fullscreen"
+        title="Open the full-screen graph browser"
+      >
+        ⛶ Full screen
+      </button>
+    </div>
     <div class="lokf-graph__canvas"></div>
     <aside class="lokf-graph__detail" hidden>
       <button type="button" class="lokf-graph__close" aria-label="Close">&times;</button>
@@ -42,6 +55,9 @@
 
 <script>
   import cytoscape from "cytoscape";
+  import fcose from "cytoscape-fcose";
+
+  cytoscape.use(fcose);
 
   const PALETTE = [
     "#5b8def", "#e8833a", "#2ea77d", "#c1558b",
@@ -88,7 +104,20 @@
     const cy = cytoscape({
       container: mount,
       elements: graph,
-      layout: { name: "cose", padding: 30, idealEdgeLength: () => 130, nodeRepulsion: () => 9000, animate: false },
+      minZoom: 0.2,
+      maxZoom: 2.5,
+      wheelSensitivity: 0.3,
+      layout: {
+        name: "fcose",
+        quality: "proof",
+        animate: false,
+        padding: 50,
+        nodeSeparation: 160,
+        idealEdgeLength: 150,
+        nodeRepulsion: 7000,
+        gravity: 0.2,
+        fit: true,
+      },
       style: [
         {
           selector: "node",
@@ -194,6 +223,30 @@
       "click",
       () => (detail.hidden = true),
     );
+
+    // Zoom to fit once the force layout settles (fcose fits too, but a re-fit
+    // after the container has its final size avoids the "too zoomed in" start).
+    const fit = () => cy.fit(undefined, 45);
+    cy.one("layoutstop", () => requestAnimationFrame(fit));
+
+    // Toolbar: fit + a full-screen graph browser (the whole explorer — search,
+    // filters, and graph — fills the viewport).
+    root.querySelector('[data-action="fit"]')!.addEventListener("click", fit);
+    const fsBtn = root.querySelector('[data-action="fullscreen"]') as HTMLButtonElement;
+    fsBtn.addEventListener("click", () => {
+      if (document.fullscreenElement) document.exitFullscreen();
+      else root.requestFullscreen?.();
+    });
+    document.addEventListener("fullscreenchange", () => {
+      const full = document.fullscreenElement === root;
+      root.classList.toggle("is-fullscreen", full);
+      fsBtn.textContent = full ? "⛶ Exit full screen" : "⛶ Full screen";
+      // Let the layout reflow to the new size before resizing the canvas.
+      requestAnimationFrame(() => {
+        cy.resize();
+        fit();
+      });
+    });
   }
 
   // This module script is deferred, so the DOM is ready — boot now. Also
@@ -262,13 +315,53 @@
   .lokf-graph__stage {
     position: relative;
   }
+  .lokf-graph__toolbar {
+    position: absolute;
+    top: 0.55rem;
+    left: 0.55rem;
+    z-index: 3;
+    display: flex;
+    gap: 0.4rem;
+  }
+  .lokf-graph__btn {
+    font-size: 0.75rem;
+    padding: 0.28rem 0.6rem;
+    color: var(--sl-color-text);
+    background: var(--sl-color-black);
+    border: 1px solid var(--sl-color-gray-5);
+    border-radius: 0.35rem;
+    cursor: pointer;
+    line-height: 1.4;
+  }
+  .lokf-graph__btn:hover {
+    border-color: var(--sl-color-accent);
+    color: var(--sl-color-accent-high);
+  }
   .lokf-graph__canvas {
     width: 100%;
     height: 60vh;
-    min-height: 420px;
+    min-height: 460px;
     border: 1px solid var(--sl-color-gray-5);
     border-radius: 0.5rem;
     background: var(--sl-color-gray-7, var(--sl-color-black));
+  }
+  /* Full-screen graph browser: the whole explorer — search, filters, and
+     graph — fills the viewport, with the graph stage taking the leftover
+     height. */
+  .lokf-graph.is-fullscreen {
+    margin: 0;
+    padding: 1rem;
+    display: flex;
+    flex-direction: column;
+    background: var(--sl-color-bg);
+  }
+  .lokf-graph.is-fullscreen .lokf-graph__stage {
+    flex: 1;
+    min-height: 0;
+  }
+  .lokf-graph.is-fullscreen .lokf-graph__canvas {
+    height: 100%;
+    min-height: 0;
   }
   .lokf-graph__detail {
     position: absolute;


### PR DESCRIPTION
## What

Addresses four papercuts on the docs site:

**Knowledge-graph page (`/graph/`)**
- Was rendering too zoomed-in and cluttered. Switched the cytoscape layout from `cose` to **fcose** (`cytoscape-fcose`) with wider node separation (`nodeSeparation: 160`, `idealEdgeLength: 150`), and re-fit to the container after the force layout settles (`layoutstop` → `cy.fit`) so it no longer starts overzoomed. Also set `minZoom`/`maxZoom`/`wheelSensitivity` for saner mouse-wheel zoom.
- Added a small toolbar with **⤢ Fit** (re-fit to view) and **⛶ Full screen**. Full screen promotes the *whole* explorer — search + filters + graph — to the viewport via the Fullscreen API, so it becomes a real graph browser; the canvas reflows to fill the leftover height and re-fits on enter/exit.

**Markdown → RDF page (`/guide/markdown-to-rdf/`)**
- The worked example was labelled "Turtle" but actually printed flat **N-Triples**. Rewrote it as compact, prefixed, indented Turtle (the serialization that should be the default throughout).
- Fenced the `weekly-active-users.nt` example as `turtle` (N-Triples is a subset of Turtle) so it — and the YAML frontmatter blocks — get **syntax highlighting** via Expressive Code.

## Verification
- `npm run build` green (21 pages); `npm ci` consistent (also prunes some unused mermaid-SSR lock entries).
- Dev server: fcose renders the 6-node graph fit at ~0.6 zoom (was overzoomed); Fit button re-fits; fullscreen toggles the full-viewport browser layout.
- markdown-to-rdf now serves compact Turtle (no N-Triples), with syntax-highlight spans present.