### PR TITLE
Add AI Covenant + CONTRIBUTING; note AI assistance in README

### DIFF
--- a/AI_COVENANT.md
+++ b/AI_COVENANT.md
@@ -1,0 +1,111 @@
+# AI Covenant for LOKF
+
+This covenant sets the norms for responsible AI use in the LOKF project. LOKF is
+developed openly and with substantial AI assistance; this document makes the
+resulting expectations explicit: AI is a tool that accelerates the work, but
+every contribution is owned, understood, and defended by a human.
+
+It applies to this repository:
+
+- <https://github.com/nicholsn/lokf>
+
+It is adapted from the
+[LinkML AI Covenant](https://github.com/linkml/linkml/blob/main/AI_COVENANT.md).
+
+## Core principle: you own your contributions
+
+**Everything you contribute is yours — regardless of what tools helped create it.**
+
+When you submit code, schema changes, documentation, issues, or comments with AI
+assistance, *you* are the author. You are responsible for:
+
+- Understanding what you are submitting
+- Verifying its correctness and appropriateness
+- Defending and explaining your choices during review
+- Ensuring it meets the project's standards
+
+Do not submit anything you cannot fully stand behind.
+
+## No AI co-authorship
+
+AI tools are **not** credited as authors or co-authors. Commit messages and pull
+requests **MUST NOT** add `Co-Authored-By` trailers (or equivalent) for an AI
+assistant. The human who runs the tool is the sole author and takes full
+responsibility for the result.
+
+## Generated artifacts
+
+LOKF is defined once in `lokf.yaml`; the JSON-LD context, JSON Schema, SHACL
+shapes, and OWL ontology are generated from it. AI assistance does not change
+that contract: propose changes in `lokf.yaml` (or the toolkit, docs, or tests),
+regenerate with `just build`, and commit the regenerated artifacts — never
+hand-edit a generated file, whether by hand or with an AI.
+
+## AI-assisted code reviews
+
+AI review tools (Claude, Copilot, CodeRabbit, etc.) provide **automated quality
+checks, not human reviews**.
+
+- AI comments are suggestions, not requirements.
+- PR owners may resolve AI comments without responding.
+- Human reviewers may use AI feedback to inform their own review.
+- A PR still requires human approval regardless of AI feedback.
+
+## AI-assisted discussions
+
+AI tools can be helpful **thinking aids** when preparing to participate in issues
+and discussions. They may be used to clarify your own thinking, explore
+alternative framings, or help draft *your* contribution for clarity and structure.
+
+However, discussions exist to **surface, negotiate, and consolidate human
+judgement**. AI systems **MUST NOT** be used to autonomously post comments,
+replies, or messages in GitHub issues or discussions. Every contribution must
+reflect a **human position** the author is prepared to explain, revise, and
+defend. Posting AI-generated commentary as an independent "voice" undermines
+trust, accountability, and the purpose of deliberation.
+
+In short: AI may *support* participation; humans must *own* it.
+
+## When to disclose AI assistance
+
+**Required:**
+
+- When proposing a fix or change to code or schema you don't fully understand,
+  attribute the idea to AI so reviewers can assess it appropriately.
+
+**Appreciated:**
+
+- When brainstorming, distinguish "AI suggests X" from "I recommend X based on my
+  own judgement." This helps prioritize ideas.
+
+**Not required:**
+
+- Routine use of AI to write code, schema, docs, issues, or PR descriptions.
+- (AI co-authorship in commit messages is not merely "not required" — it is
+  disallowed; see [No AI co-authorship](#no-ai-co-authorship).)
+
+## What this means in practice
+
+| Situation | Guidance |
+| --------- | -------- |
+| Writing code/schema/docs with Claude/Copilot | No disclosure needed; you own the result |
+| Submitting an AI-suggested change you fully understand | No disclosure needed |
+| Submitting an AI-suggested change in unfamiliar territory | Disclose the AI origin for reviewer context |
+| Drafting an issue or PR description with AI | No disclosure needed; ensure it's accurate |
+| Brainstorming in discussions | Be clear about AI-generated vs. your own ideas |
+| Receiving AI review comments | Address or resolve at your discretion |
+| Crediting an AI as a commit author or co-author | Not allowed |
+
+## Trust and accountability
+
+This covenant is built on trust. By contributing to LOKF, you agree that:
+
+1. You will not submit AI-generated content without reviewing it.
+2. You take responsibility for any issues arising from your contributions.
+3. You will be honest about the origin of ideas when it matters for review quality.
+
+---
+
+*This covenant may evolve as AI tools and community needs change. It is adapted
+from the [LinkML AI Covenant](https://github.com/linkml/linkml/blob/main/AI_COVENANT.md).
+Feedback and suggestions are welcome.*

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,20 @@
+# Contributing to LOKF
+
+Thanks for your interest in the Linked Open Knowledge Format! The full guide
+lives in the documentation: <https://lokf.nolan-nichols.com/contributing/>.
+
+A few essentials:
+
+- **One source of truth.** LOKF is defined in `lokf.yaml`. The JSON-LD context,
+  JSON Schema, SHACL shapes, and OWL ontology are all generated from it. Edit
+  `lokf.yaml` (or the toolkit in `src/`, the docs in `web/`, or the tests), then
+  run `just build` to regenerate every artifact and re-validate the reference
+  bundle — never hand-edit a generated file.
+- **Verify before you push.** `just build` and `just test` must pass, and any
+  regenerated artifacts must be committed alongside the schema change.
+- **Reuse public vocabulary.** New types and fields should map to established
+  ontology terms (schema.org, DCAT, PROV-O, SKOS, W3C ORG, …) rather than mint
+  new ones — reuse is the whole point of LOKF.
+- **Responsible AI use.** LOKF is built with AI assistance. Please review the
+  [AI Covenant](AI_COVENANT.md): you own everything you submit, and AI is never
+  credited as a commit co-author.

--- a/README.md
+++ b/README.md
@@ -148,6 +148,15 @@ Google**. "Open Knowledge Format" / "OKF" refer to the format published by Googl
 Cloud (`github.com/GoogleCloudPlatform/knowledge-catalog`); LOKF extends it under
 its open terms.
 
+## AI assistance
+
+LOKF is developed openly and with substantial AI assistance (Claude) — including
+the toolkit, the LinkML schema, the documentation, and this README. Nolan
+Nichols reviews and takes full responsibility for everything committed. Per the
+project's [AI Covenant](AI_COVENANT.md), AI is a tool, not a co-author: it is
+never credited in commit messages, and every contribution is owned and defended
+by a human. See [CONTRIBUTING.md](CONTRIBUTING.md) to get involved.
+
 ## License
 
 CC-BY-4.0 — see [`LICENSE`](https://github.com/nicholsn/lokf/blob/main/LICENSE).

--- a/web/astro.config.mjs
+++ b/web/astro.config.mjs
@@ -38,6 +38,7 @@ export default defineConfig({
           label: "Reference",
           items: [{ autogenerate: { directory: "reference" } }],
         },
+        { label: "Contributing", slug: "contributing" },
       ],
     }),
   ],

--- a/web/src/content/docs/contributing.md
+++ b/web/src/content/docs/contributing.md
@@ -1,0 +1,72 @@
+---
+title: Contributing
+description: How to contribute to LOKF — the build model, the single source of truth, and responsible AI use.
+---
+
+Contributions are welcome — a new concept type, a mapping fix, a documentation
+improvement, or a bug report.
+
+## The single source of truth
+
+LOKF is defined **once** in
+[`lokf.yaml`](https://github.com/nicholsn/lokf/blob/main/lokf.yaml), a
+[LinkML](https://linkml.io) schema. The JSON-LD context, JSON Schema, SHACL
+shapes, and OWL ontology are **generated** from it — never hand-edit them.
+
+| File | Hand-edit? |
+| ---- | :--------: |
+| `lokf.yaml` | ✅ the schema |
+| `SPEC.md`, `examples/…/*.md`, `web/…` | ✅ prose, examples, docs |
+| `lokf.context.jsonld`, `lokf.schema.json`, `lokf.shacl.ttl`, `lokf.owl.ttl`, `examples/*.nt` | ⚙️ generated |
+
+## Set up
+
+```bash
+git clone https://github.com/nicholsn/lokf
+cd lokf
+uv sync
+```
+
+## Make a change
+
+1. Edit the source: `lokf.yaml` for the vocabulary, `src/lokf/` for the toolkit,
+   `examples/` for the reference bundle, or `web/` for these docs.
+2. When adding a **type** or **field**, map it to an established public ontology
+   term (schema.org, DCAT, PROV-O, SKOS, W3C ORG, …) rather than minting a new
+   term — reuse is the whole point of LOKF.
+3. Regenerate and re-validate everything:
+
+   ```bash
+   just build     # regenerate artifacts + re-validate the reference bundle
+   just test      # run the test suite
+   ```
+
+4. Commit the regenerated artifacts alongside your schema change, so the
+   generated files never drift from `lokf.yaml`.
+
+## Open a pull request
+
+- `just build` and `just test` must pass.
+- Regenerated artifacts are committed.
+- Describe the change and the reasoning; if you touched the vocabulary, note
+  which public terms you reused and why.
+
+## Responsible AI use
+
+LOKF is built openly with AI assistance, and we ask contributors to use these
+tools responsibly. The essentials:
+
+- **You own what you submit.** Regardless of what tools helped, you are the
+  author — understand it, verify it, and be ready to defend it in review.
+- **No AI co-authorship.** AI is never credited as a commit author or
+  co-author; the human running the tool is solely responsible.
+- **Disclose when it matters.** If you propose a change in code or schema you
+  don't fully understand, say that AI suggested it so reviewers can weigh it
+  appropriately.
+- **Humans own discussion.** AI can help you draft, but must not autonomously
+  post to issues or discussions.
+
+The full policy is the
+[AI Covenant](https://github.com/nicholsn/lokf/blob/main/AI_COVENANT.md),
+adapted from the
+[LinkML AI Covenant](https://github.com/linkml/linkml/blob/main/AI_COVENANT.md).


### PR DESCRIPTION
Reviews the README for correctness and adopts an AI-use policy modeled on the [LinkML AI Covenant](https://github.com/linkml/linkml/blob/main/AI_COVENANT.md), documenting contribution norms in both the repo files and the docs site.

### README
Reviewed for correctness — the technical claims match the code (`lokf.rdf.serialize` exists; the CLI `--format` accepts exactly `ttl | nt | jsonld | xml | n3 | trig`; the generated-files table and build commands are accurate). Added an **AI assistance** note: LOKF is developed with AI (Claude), the author reviews and takes full responsibility for every commit, and **AI is a tool, not a co-author** (never credited in commit messages).

### New policy + contribution docs
- **`AI_COVENANT.md`** — adapted from LinkML's, tailored to LOKF. Keeps the core principles (you own your contributions; AI reviews are suggestions; humans own discussions; disclose AI-origin for unfamiliar changes) and adds:
  - an explicit **"No AI co-authorship"** rule — `Co-Authored-By` trailers for an AI are disallowed;
  - a **generated-artifacts** clause — edit `lokf.yaml` and regenerate; never hand-edit a generated file, including with an AI.
- **`CONTRIBUTING.md`** (root) — short guide: single source of truth, verify with `just build` / `just test`, reuse public vocabulary, and a pointer to the covenant. Mirrors LinkML's pattern (stub + link to docs + covenant reference).
- **`web/` docs** — a new **Contributing** page (added to the sidebar) with the full workflow and a "Responsible AI use" section linking the covenant.

Docs build clean (22 pages; the `/contributing` page renders). Per the covenant it introduces, this PR has no AI co-author.