### PR TITLE
Phase 1: Python bindings + relational schema (the tabular projection)

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,8 @@ and every OKF bundle is valid LOKF with default mappings.
 | `lokf.schema.json` | Generated JSON Schema — validates frontmatter / bundles. | ⚙️ generated |
 | `lokf.shacl.ttl` | Generated SHACL shapes — validates the RDF graph. | ⚙️ generated |
 | `lokf.owl.ttl` | Generated OWL ontology — reasoning & alignment. | ⚙️ generated |
+| `lokf.sql` | Generated relational schema — `CREATE TABLE` DDL (FKs for typed relations). | ⚙️ generated |
+| `src/lokf/datamodel.py` | Generated Python bindings — `from lokf.datamodel import Metric`. | ⚙️ generated |
 | `examples/acme-knowledge/` | A conformant 6-concept reference bundle. | ✅ |
 | `examples/*.nt` | RDF triples produced from the example frontmatter. | ⚙️ generated |
 
@@ -140,6 +142,27 @@ print(rdf.serialize("examples/acme-knowledge/metrics/weekly-active-users.md", "t
 <!-- --8<-- [end:quickstart-rdf] -->
 
 This is the whole thesis: OKF authoring in, RDF knowledge graph out.
+
+## Two projections: a graph *and* tables
+
+Because LOKF is defined once in LinkML, a well-modeled bundle projects **two**
+ways — the *literal* knowledge graph and the *abstract* one (well-modeled,
+linked data you can put in tables):
+
+- **A graph** — markdown → JSON-LD → RDF, queryable with SPARQL, validatable
+  with SHACL, reason-able with OWL (shown above).
+- **Tables** — the same schema generates typed **Python bindings**
+  (`src/lokf/datamodel.py`) and a **relational schema** (`lokf.sql` — one table
+  per type, foreign keys for the typed relations). So the same well-modeled data
+  is either a queryable graph *or* a set of linked tables: DataFrames to analyze,
+  SQL to persist, a lakehouse to scale.
+
+```python
+from lokf.datamodel import Metric
+
+Metric(id="https://acme.example/knowledge/metrics/wau",
+       type="Metric", title="Weekly Active Users", unit="users")
+```
 
 ## Status
 

--- a/lokf.sql
+++ b/lokf.sql
@@ -1,0 +1,2488 @@
+-- # Class: KnowledgeBundle Description: A self-contained, hierarchical collection of concept documents — the unit of distribution (a git repo, tarball, or subdirectory). Maps to a DCAT Catalog. When a whole bundle is serialized as a single JSON-LD document, this class is the tree root; individual concept files validate against Concept (or a subclass).
+--     * Slot: id
+--     * Slot: lokf_version Description: The LOKF version the bundle targets (e.g. "0.1").
+--     * Slot: okf_version Description: The OKF version the bundle remains compatible with (e.g. "0.1").
+--     * Slot: base_iri Description: The base IRI against which Concept IDs are resolved to produce each concept's stable `id`.
+--     * Slot: context Description: The URL of the JSON-LD @context to attach to this bundle's concepts to interpret their frontmatter as Linked Data.
+--     * Slot: title Description: Human-readable display name.
+--     * Slot: description Description: A single-sentence summary of the concept.
+--     * Slot: license Description: The license under which the concept or bundle is offered.
+--     * Slot: publisher_id Description: The agent responsible for making the bundle available.
+-- # Abstract Class: Concept Description: A single unit of knowledge within a bundle, represented as one markdown document. The abstract base of every LOKF type. Its own IRI (`id`) is the RDF subject; the markdown body and typed relations become triples about that subject.
+--     * Slot: id Description: The concept's stable IRI. By convention it is the bundle base IRI joined with the Concept ID (the file path within the bundle, minus the `.md` suffix). Becomes the JSON-LD @id / RDF subject.
+--     * Slot: type Description: The concept's type. OKF's single required field. In LOKF the value SHOULD name a LOKF class (e.g. Metric, Dataset, Table, Playbook, GlossaryTerm); it designates the JSON-LD @type / rdf:type. Consumers MUST tolerate unknown values by treating the concept as a generic lokf:Concept.
+--     * Slot: title Description: Human-readable display name.
+--     * Slot: description Description: A single-sentence summary of the concept.
+--     * Slot: resource Description: A URI that uniquely identifies the underlying real-world asset the concept describes (a table console URL, an API base URL, etc.). Absent for purely abstract concepts.
+--     * Slot: timestamp Description: ISO 8601 datetime of the last meaningful change.
+--     * Slot: created Description: ISO 8601 datetime the concept was created.
+--     * Slot: version Description: A version string for the concept's content.
+--     * Slot: license Description: The license under which the concept or bundle is offered.
+--     * Slot: body Description: The markdown body of the concept document (everything after the frontmatter). Mapped to schema:text; carried as a field only in the JSON-LD / JSON serialization, not duplicated in the frontmatter.
+--     * Slot: KnowledgeBundle_id Description: Autocreated FK slot
+-- # Class: Dataset Description: A collection of data, published or curated for access and reuse.
+--     * Slot: id Description: The concept's stable IRI. By convention it is the bundle base IRI joined with the Concept ID (the file path within the bundle, minus the `.md` suffix). Becomes the JSON-LD @id / RDF subject.
+--     * Slot: type Description: The concept's type. OKF's single required field. In LOKF the value SHOULD name a LOKF class (e.g. Metric, Dataset, Table, Playbook, GlossaryTerm); it designates the JSON-LD @type / rdf:type. Consumers MUST tolerate unknown values by treating the concept as a generic lokf:Concept.
+--     * Slot: title Description: Human-readable display name.
+--     * Slot: description Description: A single-sentence summary of the concept.
+--     * Slot: resource Description: A URI that uniquely identifies the underlying real-world asset the concept describes (a table console URL, an API base URL, etc.). Absent for purely abstract concepts.
+--     * Slot: timestamp Description: ISO 8601 datetime of the last meaningful change.
+--     * Slot: created Description: ISO 8601 datetime the concept was created.
+--     * Slot: version Description: A version string for the concept's content.
+--     * Slot: license Description: The license under which the concept or bundle is offered.
+--     * Slot: body Description: The markdown body of the concept document (everything after the frontmatter). Mapped to schema:text; carried as a field only in the JSON-LD / JSON serialization, not duplicated in the frontmatter.
+-- # Class: Table Description: A structured, tabular dataset (e.g. a warehouse table or view) whose columns are described by Field objects under `fields`.
+--     * Slot: id Description: The concept's stable IRI. By convention it is the bundle base IRI joined with the Concept ID (the file path within the bundle, minus the `.md` suffix). Becomes the JSON-LD @id / RDF subject.
+--     * Slot: type Description: The concept's type. OKF's single required field. In LOKF the value SHOULD name a LOKF class (e.g. Metric, Dataset, Table, Playbook, GlossaryTerm); it designates the JSON-LD @type / rdf:type. Consumers MUST tolerate unknown values by treating the concept as a generic lokf:Concept.
+--     * Slot: title Description: Human-readable display name.
+--     * Slot: description Description: A single-sentence summary of the concept.
+--     * Slot: resource Description: A URI that uniquely identifies the underlying real-world asset the concept describes (a table console URL, an API base URL, etc.). Absent for purely abstract concepts.
+--     * Slot: timestamp Description: ISO 8601 datetime of the last meaningful change.
+--     * Slot: created Description: ISO 8601 datetime the concept was created.
+--     * Slot: version Description: A version string for the concept's content.
+--     * Slot: license Description: The license under which the concept or bundle is offered.
+--     * Slot: body Description: The markdown body of the concept document (everything after the frontmatter). Mapped to schema:text; carried as a field only in the JSON-LD / JSON serialization, not duplicated in the frontmatter.
+-- # Class: Metric Description: A precisely defined, measurable quantity — the canonical definition of a business or operational metric.
+--     * Slot: unit Description: The unit of measurement (e.g. USD, seconds, count).
+--     * Slot: formula Description: The calculation or definition expression for a metric.
+--     * Slot: id Description: The concept's stable IRI. By convention it is the bundle base IRI joined with the Concept ID (the file path within the bundle, minus the `.md` suffix). Becomes the JSON-LD @id / RDF subject.
+--     * Slot: type Description: The concept's type. OKF's single required field. In LOKF the value SHOULD name a LOKF class (e.g. Metric, Dataset, Table, Playbook, GlossaryTerm); it designates the JSON-LD @type / rdf:type. Consumers MUST tolerate unknown values by treating the concept as a generic lokf:Concept.
+--     * Slot: title Description: Human-readable display name.
+--     * Slot: description Description: A single-sentence summary of the concept.
+--     * Slot: resource Description: A URI that uniquely identifies the underlying real-world asset the concept describes (a table console URL, an API base URL, etc.). Absent for purely abstract concepts.
+--     * Slot: timestamp Description: ISO 8601 datetime of the last meaningful change.
+--     * Slot: created Description: ISO 8601 datetime the concept was created.
+--     * Slot: version Description: A version string for the concept's content.
+--     * Slot: license Description: The license under which the concept or bundle is offered.
+--     * Slot: body Description: The markdown body of the concept document (everything after the frontmatter). Mapped to schema:text; carried as a field only in the JSON-LD / JSON serialization, not duplicated in the frontmatter.
+-- # Class: Service Description: A callable service or API endpoint.
+--     * Slot: endpoint Description: The base URL or invocation endpoint of a service.
+--     * Slot: http_method Description: The HTTP method used to invoke the service, if applicable.
+--     * Slot: documentation Description: A link to the service's documentation.
+--     * Slot: id Description: The concept's stable IRI. By convention it is the bundle base IRI joined with the Concept ID (the file path within the bundle, minus the `.md` suffix). Becomes the JSON-LD @id / RDF subject.
+--     * Slot: type Description: The concept's type. OKF's single required field. In LOKF the value SHOULD name a LOKF class (e.g. Metric, Dataset, Table, Playbook, GlossaryTerm); it designates the JSON-LD @type / rdf:type. Consumers MUST tolerate unknown values by treating the concept as a generic lokf:Concept.
+--     * Slot: title Description: Human-readable display name.
+--     * Slot: description Description: A single-sentence summary of the concept.
+--     * Slot: resource Description: A URI that uniquely identifies the underlying real-world asset the concept describes (a table console URL, an API base URL, etc.). Absent for purely abstract concepts.
+--     * Slot: timestamp Description: ISO 8601 datetime of the last meaningful change.
+--     * Slot: created Description: ISO 8601 datetime the concept was created.
+--     * Slot: version Description: A version string for the concept's content.
+--     * Slot: license Description: The license under which the concept or bundle is offered.
+--     * Slot: body Description: The markdown body of the concept document (everything after the frontmatter). Mapped to schema:text; carried as a field only in the JSON-LD / JSON serialization, not duplicated in the frontmatter.
+-- # Class: Playbook Description: A procedure or runbook — an ordered set of steps to accomplish a task or respond to an event.
+--     * Slot: id Description: The concept's stable IRI. By convention it is the bundle base IRI joined with the Concept ID (the file path within the bundle, minus the `.md` suffix). Becomes the JSON-LD @id / RDF subject.
+--     * Slot: type Description: The concept's type. OKF's single required field. In LOKF the value SHOULD name a LOKF class (e.g. Metric, Dataset, Table, Playbook, GlossaryTerm); it designates the JSON-LD @type / rdf:type. Consumers MUST tolerate unknown values by treating the concept as a generic lokf:Concept.
+--     * Slot: title Description: Human-readable display name.
+--     * Slot: description Description: A single-sentence summary of the concept.
+--     * Slot: resource Description: A URI that uniquely identifies the underlying real-world asset the concept describes (a table console URL, an API base URL, etc.). Absent for purely abstract concepts.
+--     * Slot: timestamp Description: ISO 8601 datetime of the last meaningful change.
+--     * Slot: created Description: ISO 8601 datetime the concept was created.
+--     * Slot: version Description: A version string for the concept's content.
+--     * Slot: license Description: The license under which the concept or bundle is offered.
+--     * Slot: body Description: The markdown body of the concept document (everything after the frontmatter). Mapped to schema:text; carried as a field only in the JSON-LD / JSON serialization, not duplicated in the frontmatter.
+-- # Class: Policy Description: A governance, compliance, or operational policy document.
+--     * Slot: id Description: The concept's stable IRI. By convention it is the bundle base IRI joined with the Concept ID (the file path within the bundle, minus the `.md` suffix). Becomes the JSON-LD @id / RDF subject.
+--     * Slot: type Description: The concept's type. OKF's single required field. In LOKF the value SHOULD name a LOKF class (e.g. Metric, Dataset, Table, Playbook, GlossaryTerm); it designates the JSON-LD @type / rdf:type. Consumers MUST tolerate unknown values by treating the concept as a generic lokf:Concept.
+--     * Slot: title Description: Human-readable display name.
+--     * Slot: description Description: A single-sentence summary of the concept.
+--     * Slot: resource Description: A URI that uniquely identifies the underlying real-world asset the concept describes (a table console URL, an API base URL, etc.). Absent for purely abstract concepts.
+--     * Slot: timestamp Description: ISO 8601 datetime of the last meaningful change.
+--     * Slot: created Description: ISO 8601 datetime the concept was created.
+--     * Slot: version Description: A version string for the concept's content.
+--     * Slot: license Description: The license under which the concept or bundle is offered.
+--     * Slot: body Description: The markdown body of the concept document (everything after the frontmatter). Mapped to schema:text; carried as a field only in the JSON-LD / JSON serialization, not duplicated in the frontmatter.
+-- # Class: GlossaryTerm Description: A defined term in a controlled vocabulary or glossary. Maps to schema:DefinedTerm and skos:Concept.
+--     * Slot: definition Description: The formal definition of a term.
+--     * Slot: abbreviation Description: A short form or acronym for a term.
+--     * Slot: id Description: The concept's stable IRI. By convention it is the bundle base IRI joined with the Concept ID (the file path within the bundle, minus the `.md` suffix). Becomes the JSON-LD @id / RDF subject.
+--     * Slot: type Description: The concept's type. OKF's single required field. In LOKF the value SHOULD name a LOKF class (e.g. Metric, Dataset, Table, Playbook, GlossaryTerm); it designates the JSON-LD @type / rdf:type. Consumers MUST tolerate unknown values by treating the concept as a generic lokf:Concept.
+--     * Slot: title Description: Human-readable display name.
+--     * Slot: description Description: A single-sentence summary of the concept.
+--     * Slot: resource Description: A URI that uniquely identifies the underlying real-world asset the concept describes (a table console URL, an API base URL, etc.). Absent for purely abstract concepts.
+--     * Slot: timestamp Description: ISO 8601 datetime of the last meaningful change.
+--     * Slot: created Description: ISO 8601 datetime the concept was created.
+--     * Slot: version Description: A version string for the concept's content.
+--     * Slot: license Description: The license under which the concept or bundle is offered.
+--     * Slot: body Description: The markdown body of the concept document (everything after the frontmatter). Mapped to schema:text; carried as a field only in the JSON-LD / JSON serialization, not duplicated in the frontmatter.
+-- # Class: Reference Description: A concept that mirrors an external source (a page, paper, or document) as a first-class citizen of the bundle so it can be cited and linked.
+--     * Slot: id Description: The concept's stable IRI. By convention it is the bundle base IRI joined with the Concept ID (the file path within the bundle, minus the `.md` suffix). Becomes the JSON-LD @id / RDF subject.
+--     * Slot: type Description: The concept's type. OKF's single required field. In LOKF the value SHOULD name a LOKF class (e.g. Metric, Dataset, Table, Playbook, GlossaryTerm); it designates the JSON-LD @type / rdf:type. Consumers MUST tolerate unknown values by treating the concept as a generic lokf:Concept.
+--     * Slot: title Description: Human-readable display name.
+--     * Slot: description Description: A single-sentence summary of the concept.
+--     * Slot: resource Description: A URI that uniquely identifies the underlying real-world asset the concept describes (a table console URL, an API base URL, etc.). Absent for purely abstract concepts.
+--     * Slot: timestamp Description: ISO 8601 datetime of the last meaningful change.
+--     * Slot: created Description: ISO 8601 datetime the concept was created.
+--     * Slot: version Description: A version string for the concept's content.
+--     * Slot: license Description: The license under which the concept or bundle is offered.
+--     * Slot: body Description: The markdown body of the concept document (everything after the frontmatter). Mapped to schema:text; carried as a field only in the JSON-LD / JSON serialization, not duplicated in the frontmatter.
+-- # Class: Document Description: A general knowledge document that does not fit a more specific type.
+--     * Slot: id Description: The concept's stable IRI. By convention it is the bundle base IRI joined with the Concept ID (the file path within the bundle, minus the `.md` suffix). Becomes the JSON-LD @id / RDF subject.
+--     * Slot: type Description: The concept's type. OKF's single required field. In LOKF the value SHOULD name a LOKF class (e.g. Metric, Dataset, Table, Playbook, GlossaryTerm); it designates the JSON-LD @type / rdf:type. Consumers MUST tolerate unknown values by treating the concept as a generic lokf:Concept.
+--     * Slot: title Description: Human-readable display name.
+--     * Slot: description Description: A single-sentence summary of the concept.
+--     * Slot: resource Description: A URI that uniquely identifies the underlying real-world asset the concept describes (a table console URL, an API base URL, etc.). Absent for purely abstract concepts.
+--     * Slot: timestamp Description: ISO 8601 datetime of the last meaningful change.
+--     * Slot: created Description: ISO 8601 datetime the concept was created.
+--     * Slot: version Description: A version string for the concept's content.
+--     * Slot: license Description: The license under which the concept or bundle is offered.
+--     * Slot: body Description: The markdown body of the concept document (everything after the frontmatter). Mapped to schema:text; carried as a field only in the JSON-LD / JSON serialization, not duplicated in the frontmatter.
+-- # Class: Role Description: A role an agent holds within an organization over a period of time — a job, appointment, or position. Reifies the agent–organization link so it can carry a title (roleName) and a start/end interval, following the schema.org Role and W3C ORG Membership patterns.
+--     * Slot: roleName Description: The name/title of the role held (e.g. a job title).
+--     * Slot: startDate Description: The date the role began (ISO 8601 date or year).
+--     * Slot: endDate Description: The date the role ended; omit for a role still held.
+--     * Slot: id Description: The concept's stable IRI. By convention it is the bundle base IRI joined with the Concept ID (the file path within the bundle, minus the `.md` suffix). Becomes the JSON-LD @id / RDF subject.
+--     * Slot: type Description: The concept's type. OKF's single required field. In LOKF the value SHOULD name a LOKF class (e.g. Metric, Dataset, Table, Playbook, GlossaryTerm); it designates the JSON-LD @type / rdf:type. Consumers MUST tolerate unknown values by treating the concept as a generic lokf:Concept.
+--     * Slot: title Description: Human-readable display name.
+--     * Slot: description Description: A single-sentence summary of the concept.
+--     * Slot: resource Description: A URI that uniquely identifies the underlying real-world asset the concept describes (a table console URL, an API base URL, etc.). Absent for purely abstract concepts.
+--     * Slot: timestamp Description: ISO 8601 datetime of the last meaningful change.
+--     * Slot: created Description: ISO 8601 datetime the concept was created.
+--     * Slot: version Description: A version string for the concept's content.
+--     * Slot: license Description: The license under which the concept or bundle is offered.
+--     * Slot: body Description: The markdown body of the concept document (everything after the frontmatter). Mapped to schema:text; carried as a field only in the JSON-LD / JSON serialization, not duplicated in the frontmatter.
+-- # Abstract Class: Agent Description: A person or organization responsible for a concept.
+--     * Slot: type Description: The concept's type. OKF's single required field. In LOKF the value SHOULD name a LOKF class (e.g. Metric, Dataset, Table, Playbook, GlossaryTerm); it designates the JSON-LD @type / rdf:type. Consumers MUST tolerate unknown values by treating the concept as a generic lokf:Concept.
+--     * Slot: id Description: The concept's stable IRI. By convention it is the bundle base IRI joined with the Concept ID (the file path within the bundle, minus the `.md` suffix). Becomes the JSON-LD @id / RDF subject.
+--     * Slot: name Description: A name.
+--     * Slot: email Description: Contact email address.
+--     * Slot: Concept_id Description: Autocreated FK slot
+--     * Slot: Dataset_id Description: Autocreated FK slot
+--     * Slot: Table_id Description: Autocreated FK slot
+--     * Slot: Metric_id Description: Autocreated FK slot
+--     * Slot: Service_id Description: Autocreated FK slot
+--     * Slot: Playbook_id Description: Autocreated FK slot
+--     * Slot: Policy_id Description: Autocreated FK slot
+--     * Slot: GlossaryTerm_id Description: Autocreated FK slot
+--     * Slot: Reference_id Description: Autocreated FK slot
+--     * Slot: Document_id Description: Autocreated FK slot
+--     * Slot: Role_id Description: Autocreated FK slot
+--     * Slot: Person_id Description: Autocreated FK slot
+--     * Slot: Organization_id Description: Autocreated FK slot
+-- # Class: Person Description: An individual person. Usable both as an inline Agent value (author, publisher) and as a standalone Concept document with a body and typed relations.
+--     * Slot: id Description: The concept's stable IRI. By convention it is the bundle base IRI joined with the Concept ID (the file path within the bundle, minus the `.md` suffix). Becomes the JSON-LD @id / RDF subject.
+--     * Slot: type Description: The concept's type. OKF's single required field. In LOKF the value SHOULD name a LOKF class (e.g. Metric, Dataset, Table, Playbook, GlossaryTerm); it designates the JSON-LD @type / rdf:type. Consumers MUST tolerate unknown values by treating the concept as a generic lokf:Concept.
+--     * Slot: title Description: Human-readable display name.
+--     * Slot: description Description: A single-sentence summary of the concept.
+--     * Slot: resource Description: A URI that uniquely identifies the underlying real-world asset the concept describes (a table console URL, an API base URL, etc.). Absent for purely abstract concepts.
+--     * Slot: timestamp Description: ISO 8601 datetime of the last meaningful change.
+--     * Slot: created Description: ISO 8601 datetime the concept was created.
+--     * Slot: version Description: A version string for the concept's content.
+--     * Slot: license Description: The license under which the concept or bundle is offered.
+--     * Slot: body Description: The markdown body of the concept document (everything after the frontmatter). Mapped to schema:text; carried as a field only in the JSON-LD / JSON serialization, not duplicated in the frontmatter.
+--     * Slot: name Description: A name.
+--     * Slot: email Description: Contact email address.
+-- # Class: Organization Description: An organization, team, or group. Usable both as an inline Agent value (publisher) and as a standalone Concept document with a body and typed relations.
+--     * Slot: id Description: The concept's stable IRI. By convention it is the bundle base IRI joined with the Concept ID (the file path within the bundle, minus the `.md` suffix). Becomes the JSON-LD @id / RDF subject.
+--     * Slot: type Description: The concept's type. OKF's single required field. In LOKF the value SHOULD name a LOKF class (e.g. Metric, Dataset, Table, Playbook, GlossaryTerm); it designates the JSON-LD @type / rdf:type. Consumers MUST tolerate unknown values by treating the concept as a generic lokf:Concept.
+--     * Slot: title Description: Human-readable display name.
+--     * Slot: description Description: A single-sentence summary of the concept.
+--     * Slot: resource Description: A URI that uniquely identifies the underlying real-world asset the concept describes (a table console URL, an API base URL, etc.). Absent for purely abstract concepts.
+--     * Slot: timestamp Description: ISO 8601 datetime of the last meaningful change.
+--     * Slot: created Description: ISO 8601 datetime the concept was created.
+--     * Slot: version Description: A version string for the concept's content.
+--     * Slot: license Description: The license under which the concept or bundle is offered.
+--     * Slot: body Description: The markdown body of the concept document (everything after the frontmatter). Mapped to schema:text; carried as a field only in the JSON-LD / JSON serialization, not duplicated in the frontmatter.
+--     * Slot: name Description: A name.
+--     * Slot: email Description: Contact email address.
+-- # Class: Field Description: A single column / property within a Table or Dataset schema. Maps to schema:PropertyValue.
+--     * Slot: id
+--     * Slot: name Description: A name.
+--     * Slot: datatype Description: The data type of a field.
+--     * Slot: description Description: A single-sentence summary of the concept.
+--     * Slot: unit Description: The unit of measurement (e.g. USD, seconds, count).
+--     * Slot: is_key Description: Whether the field is (part of) the primary key.
+--     * Slot: constraints Description: Free-text or expression describing constraints on a field.
+--     * Slot: Dataset_id Description: Autocreated FK slot
+--     * Slot: Table_id Description: Autocreated FK slot
+-- # Class: Distribution Description: A specific accessible form of a Dataset (a file, feed, or endpoint). Maps to dcat:Distribution.
+--     * Slot: id
+--     * Slot: name Description: A name.
+--     * Slot: description Description: A single-sentence summary of the concept.
+--     * Slot: access_url Description: A URL that gives access to a distribution.
+--     * Slot: media_type Description: The media (MIME) type of a distribution.
+--     * Slot: Dataset_id Description: Autocreated FK slot
+--     * Slot: Table_id Description: Autocreated FK slot
+-- # Class: Relation Description: A typed, reified relationship from the containing concept to a target, used when a predicate is not covered by one of the named relation slots. Modeled as an rdf:Statement (subject = the containing concept).
+--     * Slot: id
+--     * Slot: predicate Description: The relationship type. SHOULD be drawn from the RelationType vocabulary.
+--     * Slot: target Description: The IRI (or Concept ID) of the relationship's object.
+--     * Slot: relation_label Description: An optional human-readable label for the relationship.
+--     * Slot: Concept_id Description: Autocreated FK slot
+--     * Slot: Dataset_id Description: Autocreated FK slot
+--     * Slot: Table_id Description: Autocreated FK slot
+--     * Slot: Metric_id Description: Autocreated FK slot
+--     * Slot: Service_id Description: Autocreated FK slot
+--     * Slot: Playbook_id Description: Autocreated FK slot
+--     * Slot: Policy_id Description: Autocreated FK slot
+--     * Slot: GlossaryTerm_id Description: Autocreated FK slot
+--     * Slot: Reference_id Description: Autocreated FK slot
+--     * Slot: Document_id Description: Autocreated FK slot
+--     * Slot: Role_id Description: Autocreated FK slot
+--     * Slot: Person_id Description: Autocreated FK slot
+--     * Slot: Organization_id Description: Autocreated FK slot
+-- # Class: Citation Description: A reference to an external source supporting a claim in a concept's body. Attached via the schema:citation predicate.
+--     * Slot: id
+--     * Slot: title Description: Human-readable display name.
+--     * Slot: url Description: A URL.
+--     * Slot: description Description: A single-sentence summary of the concept.
+--     * Slot: Concept_id Description: Autocreated FK slot
+--     * Slot: Dataset_id Description: Autocreated FK slot
+--     * Slot: Table_id Description: Autocreated FK slot
+--     * Slot: Metric_id Description: Autocreated FK slot
+--     * Slot: Service_id Description: Autocreated FK slot
+--     * Slot: Playbook_id Description: Autocreated FK slot
+--     * Slot: Policy_id Description: Autocreated FK slot
+--     * Slot: GlossaryTerm_id Description: Autocreated FK slot
+--     * Slot: Reference_id Description: Autocreated FK slot
+--     * Slot: Document_id Description: Autocreated FK slot
+--     * Slot: Role_id Description: Autocreated FK slot
+--     * Slot: Person_id Description: Autocreated FK slot
+--     * Slot: Organization_id Description: Autocreated FK slot
+-- # Class: Concept_tags
+--     * Slot: Concept_id Description: Autocreated FK slot
+--     * Slot: tags Description: Short cross-cutting keywords for categorization.
+-- # Class: Concept_isPartOf
+--     * Slot: Concept_id Description: Autocreated FK slot
+--     * Slot: isPartOf_id Description: The target concept that this concept is a part of.
+-- # Class: Concept_hasPart
+--     * Slot: Concept_id Description: Autocreated FK slot
+--     * Slot: hasPart_id Description: A concept that is a part of this concept.
+-- # Class: Concept_references
+--     * Slot: Concept_id Description: Autocreated FK slot
+--     * Slot: references_id Description: A concept or resource this concept refers to.
+-- # Class: Concept_dependsOn
+--     * Slot: Concept_id Description: Autocreated FK slot
+--     * Slot: dependsOn_id Description: A concept this concept depends on.
+-- # Class: Concept_derivedFrom
+--     * Slot: Concept_id Description: Autocreated FK slot
+--     * Slot: derivedFrom_id Description: An entity this concept was derived from (provenance).
+-- # Class: Concept_about
+--     * Slot: Concept_id Description: Autocreated FK slot
+--     * Slot: about_id Description: The subject matter this concept is about.
+-- # Class: Concept_sameAs
+--     * Slot: Concept_id Description: Autocreated FK slot
+--     * Slot: sameAs_id Description: An IRI asserting this concept is the same entity as another.
+-- # Class: Concept_relatedTo
+--     * Slot: Concept_id Description: Autocreated FK slot
+--     * Slot: relatedTo_id Description: A generic association to another concept.
+-- # Class: Concept_definedBy
+--     * Slot: Concept_id Description: Autocreated FK slot
+--     * Slot: definedBy_id Description: A resource that formally defines this concept.
+-- # Class: Concept_source
+--     * Slot: Concept_id Description: Autocreated FK slot
+--     * Slot: source_id Description: A resource from which this concept is derived or sourced.
+-- # Class: Dataset_tags
+--     * Slot: Dataset_id Description: Autocreated FK slot
+--     * Slot: tags Description: Short cross-cutting keywords for categorization.
+-- # Class: Dataset_isPartOf
+--     * Slot: Dataset_id Description: Autocreated FK slot
+--     * Slot: isPartOf_id Description: The target concept that this concept is a part of.
+-- # Class: Dataset_hasPart
+--     * Slot: Dataset_id Description: Autocreated FK slot
+--     * Slot: hasPart_id Description: A concept that is a part of this concept.
+-- # Class: Dataset_references
+--     * Slot: Dataset_id Description: Autocreated FK slot
+--     * Slot: references_id Description: A concept or resource this concept refers to.
+-- # Class: Dataset_dependsOn
+--     * Slot: Dataset_id Description: Autocreated FK slot
+--     * Slot: dependsOn_id Description: A concept this concept depends on.
+-- # Class: Dataset_derivedFrom
+--     * Slot: Dataset_id Description: Autocreated FK slot
+--     * Slot: derivedFrom_id Description: An entity this concept was derived from (provenance).
+-- # Class: Dataset_about
+--     * Slot: Dataset_id Description: Autocreated FK slot
+--     * Slot: about_id Description: The subject matter this concept is about.
+-- # Class: Dataset_sameAs
+--     * Slot: Dataset_id Description: Autocreated FK slot
+--     * Slot: sameAs_id Description: An IRI asserting this concept is the same entity as another.
+-- # Class: Dataset_relatedTo
+--     * Slot: Dataset_id Description: Autocreated FK slot
+--     * Slot: relatedTo_id Description: A generic association to another concept.
+-- # Class: Dataset_definedBy
+--     * Slot: Dataset_id Description: Autocreated FK slot
+--     * Slot: definedBy_id Description: A resource that formally defines this concept.
+-- # Class: Dataset_source
+--     * Slot: Dataset_id Description: Autocreated FK slot
+--     * Slot: source_id Description: A resource from which this concept is derived or sourced.
+-- # Class: Table_tags
+--     * Slot: Table_id Description: Autocreated FK slot
+--     * Slot: tags Description: Short cross-cutting keywords for categorization.
+-- # Class: Table_isPartOf
+--     * Slot: Table_id Description: Autocreated FK slot
+--     * Slot: isPartOf_id Description: The target concept that this concept is a part of.
+-- # Class: Table_hasPart
+--     * Slot: Table_id Description: Autocreated FK slot
+--     * Slot: hasPart_id Description: A concept that is a part of this concept.
+-- # Class: Table_references
+--     * Slot: Table_id Description: Autocreated FK slot
+--     * Slot: references_id Description: A concept or resource this concept refers to.
+-- # Class: Table_dependsOn
+--     * Slot: Table_id Description: Autocreated FK slot
+--     * Slot: dependsOn_id Description: A concept this concept depends on.
+-- # Class: Table_derivedFrom
+--     * Slot: Table_id Description: Autocreated FK slot
+--     * Slot: derivedFrom_id Description: An entity this concept was derived from (provenance).
+-- # Class: Table_about
+--     * Slot: Table_id Description: Autocreated FK slot
+--     * Slot: about_id Description: The subject matter this concept is about.
+-- # Class: Table_sameAs
+--     * Slot: Table_id Description: Autocreated FK slot
+--     * Slot: sameAs_id Description: An IRI asserting this concept is the same entity as another.
+-- # Class: Table_relatedTo
+--     * Slot: Table_id Description: Autocreated FK slot
+--     * Slot: relatedTo_id Description: A generic association to another concept.
+-- # Class: Table_definedBy
+--     * Slot: Table_id Description: Autocreated FK slot
+--     * Slot: definedBy_id Description: A resource that formally defines this concept.
+-- # Class: Table_source
+--     * Slot: Table_id Description: Autocreated FK slot
+--     * Slot: source_id Description: A resource from which this concept is derived or sourced.
+-- # Class: Metric_measures
+--     * Slot: Metric_id Description: Autocreated FK slot
+--     * Slot: measures_id Description: What the metric measures (a concept IRI or description).
+-- # Class: Metric_tags
+--     * Slot: Metric_id Description: Autocreated FK slot
+--     * Slot: tags Description: Short cross-cutting keywords for categorization.
+-- # Class: Metric_isPartOf
+--     * Slot: Metric_id Description: Autocreated FK slot
+--     * Slot: isPartOf_id Description: The target concept that this concept is a part of.
+-- # Class: Metric_hasPart
+--     * Slot: Metric_id Description: Autocreated FK slot
+--     * Slot: hasPart_id Description: A concept that is a part of this concept.
+-- # Class: Metric_references
+--     * Slot: Metric_id Description: Autocreated FK slot
+--     * Slot: references_id Description: A concept or resource this concept refers to.
+-- # Class: Metric_dependsOn
+--     * Slot: Metric_id Description: Autocreated FK slot
+--     * Slot: dependsOn_id Description: A concept this concept depends on.
+-- # Class: Metric_derivedFrom
+--     * Slot: Metric_id Description: Autocreated FK slot
+--     * Slot: derivedFrom_id Description: An entity this concept was derived from (provenance).
+-- # Class: Metric_about
+--     * Slot: Metric_id Description: Autocreated FK slot
+--     * Slot: about_id Description: The subject matter this concept is about.
+-- # Class: Metric_sameAs
+--     * Slot: Metric_id Description: Autocreated FK slot
+--     * Slot: sameAs_id Description: An IRI asserting this concept is the same entity as another.
+-- # Class: Metric_relatedTo
+--     * Slot: Metric_id Description: Autocreated FK slot
+--     * Slot: relatedTo_id Description: A generic association to another concept.
+-- # Class: Metric_definedBy
+--     * Slot: Metric_id Description: Autocreated FK slot
+--     * Slot: definedBy_id Description: A resource that formally defines this concept.
+-- # Class: Metric_source
+--     * Slot: Metric_id Description: Autocreated FK slot
+--     * Slot: source_id Description: A resource from which this concept is derived or sourced.
+-- # Class: Service_tags
+--     * Slot: Service_id Description: Autocreated FK slot
+--     * Slot: tags Description: Short cross-cutting keywords for categorization.
+-- # Class: Service_isPartOf
+--     * Slot: Service_id Description: Autocreated FK slot
+--     * Slot: isPartOf_id Description: The target concept that this concept is a part of.
+-- # Class: Service_hasPart
+--     * Slot: Service_id Description: Autocreated FK slot
+--     * Slot: hasPart_id Description: A concept that is a part of this concept.
+-- # Class: Service_references
+--     * Slot: Service_id Description: Autocreated FK slot
+--     * Slot: references_id Description: A concept or resource this concept refers to.
+-- # Class: Service_dependsOn
+--     * Slot: Service_id Description: Autocreated FK slot
+--     * Slot: dependsOn_id Description: A concept this concept depends on.
+-- # Class: Service_derivedFrom
+--     * Slot: Service_id Description: Autocreated FK slot
+--     * Slot: derivedFrom_id Description: An entity this concept was derived from (provenance).
+-- # Class: Service_about
+--     * Slot: Service_id Description: Autocreated FK slot
+--     * Slot: about_id Description: The subject matter this concept is about.
+-- # Class: Service_sameAs
+--     * Slot: Service_id Description: Autocreated FK slot
+--     * Slot: sameAs_id Description: An IRI asserting this concept is the same entity as another.
+-- # Class: Service_relatedTo
+--     * Slot: Service_id Description: Autocreated FK slot
+--     * Slot: relatedTo_id Description: A generic association to another concept.
+-- # Class: Service_definedBy
+--     * Slot: Service_id Description: Autocreated FK slot
+--     * Slot: definedBy_id Description: A resource that formally defines this concept.
+-- # Class: Service_source
+--     * Slot: Service_id Description: Autocreated FK slot
+--     * Slot: source_id Description: A resource from which this concept is derived or sourced.
+-- # Class: Playbook_tags
+--     * Slot: Playbook_id Description: Autocreated FK slot
+--     * Slot: tags Description: Short cross-cutting keywords for categorization.
+-- # Class: Playbook_isPartOf
+--     * Slot: Playbook_id Description: Autocreated FK slot
+--     * Slot: isPartOf_id Description: The target concept that this concept is a part of.
+-- # Class: Playbook_hasPart
+--     * Slot: Playbook_id Description: Autocreated FK slot
+--     * Slot: hasPart_id Description: A concept that is a part of this concept.
+-- # Class: Playbook_references
+--     * Slot: Playbook_id Description: Autocreated FK slot
+--     * Slot: references_id Description: A concept or resource this concept refers to.
+-- # Class: Playbook_dependsOn
+--     * Slot: Playbook_id Description: Autocreated FK slot
+--     * Slot: dependsOn_id Description: A concept this concept depends on.
+-- # Class: Playbook_derivedFrom
+--     * Slot: Playbook_id Description: Autocreated FK slot
+--     * Slot: derivedFrom_id Description: An entity this concept was derived from (provenance).
+-- # Class: Playbook_about
+--     * Slot: Playbook_id Description: Autocreated FK slot
+--     * Slot: about_id Description: The subject matter this concept is about.
+-- # Class: Playbook_sameAs
+--     * Slot: Playbook_id Description: Autocreated FK slot
+--     * Slot: sameAs_id Description: An IRI asserting this concept is the same entity as another.
+-- # Class: Playbook_relatedTo
+--     * Slot: Playbook_id Description: Autocreated FK slot
+--     * Slot: relatedTo_id Description: A generic association to another concept.
+-- # Class: Playbook_definedBy
+--     * Slot: Playbook_id Description: Autocreated FK slot
+--     * Slot: definedBy_id Description: A resource that formally defines this concept.
+-- # Class: Playbook_source
+--     * Slot: Playbook_id Description: Autocreated FK slot
+--     * Slot: source_id Description: A resource from which this concept is derived or sourced.
+-- # Class: Policy_tags
+--     * Slot: Policy_id Description: Autocreated FK slot
+--     * Slot: tags Description: Short cross-cutting keywords for categorization.
+-- # Class: Policy_isPartOf
+--     * Slot: Policy_id Description: Autocreated FK slot
+--     * Slot: isPartOf_id Description: The target concept that this concept is a part of.
+-- # Class: Policy_hasPart
+--     * Slot: Policy_id Description: Autocreated FK slot
+--     * Slot: hasPart_id Description: A concept that is a part of this concept.
+-- # Class: Policy_references
+--     * Slot: Policy_id Description: Autocreated FK slot
+--     * Slot: references_id Description: A concept or resource this concept refers to.
+-- # Class: Policy_dependsOn
+--     * Slot: Policy_id Description: Autocreated FK slot
+--     * Slot: dependsOn_id Description: A concept this concept depends on.
+-- # Class: Policy_derivedFrom
+--     * Slot: Policy_id Description: Autocreated FK slot
+--     * Slot: derivedFrom_id Description: An entity this concept was derived from (provenance).
+-- # Class: Policy_about
+--     * Slot: Policy_id Description: Autocreated FK slot
+--     * Slot: about_id Description: The subject matter this concept is about.
+-- # Class: Policy_sameAs
+--     * Slot: Policy_id Description: Autocreated FK slot
+--     * Slot: sameAs_id Description: An IRI asserting this concept is the same entity as another.
+-- # Class: Policy_relatedTo
+--     * Slot: Policy_id Description: Autocreated FK slot
+--     * Slot: relatedTo_id Description: A generic association to another concept.
+-- # Class: Policy_definedBy
+--     * Slot: Policy_id Description: Autocreated FK slot
+--     * Slot: definedBy_id Description: A resource that formally defines this concept.
+-- # Class: Policy_source
+--     * Slot: Policy_id Description: Autocreated FK slot
+--     * Slot: source_id Description: A resource from which this concept is derived or sourced.
+-- # Class: GlossaryTerm_tags
+--     * Slot: GlossaryTerm_id Description: Autocreated FK slot
+--     * Slot: tags Description: Short cross-cutting keywords for categorization.
+-- # Class: GlossaryTerm_isPartOf
+--     * Slot: GlossaryTerm_id Description: Autocreated FK slot
+--     * Slot: isPartOf_id Description: The target concept that this concept is a part of.
+-- # Class: GlossaryTerm_hasPart
+--     * Slot: GlossaryTerm_id Description: Autocreated FK slot
+--     * Slot: hasPart_id Description: A concept that is a part of this concept.
+-- # Class: GlossaryTerm_references
+--     * Slot: GlossaryTerm_id Description: Autocreated FK slot
+--     * Slot: references_id Description: A concept or resource this concept refers to.
+-- # Class: GlossaryTerm_dependsOn
+--     * Slot: GlossaryTerm_id Description: Autocreated FK slot
+--     * Slot: dependsOn_id Description: A concept this concept depends on.
+-- # Class: GlossaryTerm_derivedFrom
+--     * Slot: GlossaryTerm_id Description: Autocreated FK slot
+--     * Slot: derivedFrom_id Description: An entity this concept was derived from (provenance).
+-- # Class: GlossaryTerm_about
+--     * Slot: GlossaryTerm_id Description: Autocreated FK slot
+--     * Slot: about_id Description: The subject matter this concept is about.
+-- # Class: GlossaryTerm_sameAs
+--     * Slot: GlossaryTerm_id Description: Autocreated FK slot
+--     * Slot: sameAs_id Description: An IRI asserting this concept is the same entity as another.
+-- # Class: GlossaryTerm_relatedTo
+--     * Slot: GlossaryTerm_id Description: Autocreated FK slot
+--     * Slot: relatedTo_id Description: A generic association to another concept.
+-- # Class: GlossaryTerm_definedBy
+--     * Slot: GlossaryTerm_id Description: Autocreated FK slot
+--     * Slot: definedBy_id Description: A resource that formally defines this concept.
+-- # Class: GlossaryTerm_source
+--     * Slot: GlossaryTerm_id Description: Autocreated FK slot
+--     * Slot: source_id Description: A resource from which this concept is derived or sourced.
+-- # Class: Reference_tags
+--     * Slot: Reference_id Description: Autocreated FK slot
+--     * Slot: tags Description: Short cross-cutting keywords for categorization.
+-- # Class: Reference_isPartOf
+--     * Slot: Reference_id Description: Autocreated FK slot
+--     * Slot: isPartOf_id Description: The target concept that this concept is a part of.
+-- # Class: Reference_hasPart
+--     * Slot: Reference_id Description: Autocreated FK slot
+--     * Slot: hasPart_id Description: A concept that is a part of this concept.
+-- # Class: Reference_references
+--     * Slot: Reference_id Description: Autocreated FK slot
+--     * Slot: references_id Description: A concept or resource this concept refers to.
+-- # Class: Reference_dependsOn
+--     * Slot: Reference_id Description: Autocreated FK slot
+--     * Slot: dependsOn_id Description: A concept this concept depends on.
+-- # Class: Reference_derivedFrom
+--     * Slot: Reference_id Description: Autocreated FK slot
+--     * Slot: derivedFrom_id Description: An entity this concept was derived from (provenance).
+-- # Class: Reference_about
+--     * Slot: Reference_id Description: Autocreated FK slot
+--     * Slot: about_id Description: The subject matter this concept is about.
+-- # Class: Reference_sameAs
+--     * Slot: Reference_id Description: Autocreated FK slot
+--     * Slot: sameAs_id Description: An IRI asserting this concept is the same entity as another.
+-- # Class: Reference_relatedTo
+--     * Slot: Reference_id Description: Autocreated FK slot
+--     * Slot: relatedTo_id Description: A generic association to another concept.
+-- # Class: Reference_definedBy
+--     * Slot: Reference_id Description: Autocreated FK slot
+--     * Slot: definedBy_id Description: A resource that formally defines this concept.
+-- # Class: Reference_source
+--     * Slot: Reference_id Description: Autocreated FK slot
+--     * Slot: source_id Description: A resource from which this concept is derived or sourced.
+-- # Class: Document_tags
+--     * Slot: Document_id Description: Autocreated FK slot
+--     * Slot: tags Description: Short cross-cutting keywords for categorization.
+-- # Class: Document_isPartOf
+--     * Slot: Document_id Description: Autocreated FK slot
+--     * Slot: isPartOf_id Description: The target concept that this concept is a part of.
+-- # Class: Document_hasPart
+--     * Slot: Document_id Description: Autocreated FK slot
+--     * Slot: hasPart_id Description: A concept that is a part of this concept.
+-- # Class: Document_references
+--     * Slot: Document_id Description: Autocreated FK slot
+--     * Slot: references_id Description: A concept or resource this concept refers to.
+-- # Class: Document_dependsOn
+--     * Slot: Document_id Description: Autocreated FK slot
+--     * Slot: dependsOn_id Description: A concept this concept depends on.
+-- # Class: Document_derivedFrom
+--     * Slot: Document_id Description: Autocreated FK slot
+--     * Slot: derivedFrom_id Description: An entity this concept was derived from (provenance).
+-- # Class: Document_about
+--     * Slot: Document_id Description: Autocreated FK slot
+--     * Slot: about_id Description: The subject matter this concept is about.
+-- # Class: Document_sameAs
+--     * Slot: Document_id Description: Autocreated FK slot
+--     * Slot: sameAs_id Description: An IRI asserting this concept is the same entity as another.
+-- # Class: Document_relatedTo
+--     * Slot: Document_id Description: Autocreated FK slot
+--     * Slot: relatedTo_id Description: A generic association to another concept.
+-- # Class: Document_definedBy
+--     * Slot: Document_id Description: Autocreated FK slot
+--     * Slot: definedBy_id Description: A resource that formally defines this concept.
+-- # Class: Document_source
+--     * Slot: Document_id Description: Autocreated FK slot
+--     * Slot: source_id Description: A resource from which this concept is derived or sourced.
+-- # Class: Role_memberOf
+--     * Slot: Role_id Description: Autocreated FK slot
+--     * Slot: memberOf_id Description: The organization within which the role is held.
+-- # Class: Role_holder
+--     * Slot: Role_id Description: Autocreated FK slot
+--     * Slot: holder_id Description: The agent (typically a Person) who holds the role.
+-- # Class: Role_tags
+--     * Slot: Role_id Description: Autocreated FK slot
+--     * Slot: tags Description: Short cross-cutting keywords for categorization.
+-- # Class: Role_isPartOf
+--     * Slot: Role_id Description: Autocreated FK slot
+--     * Slot: isPartOf_id Description: The target concept that this concept is a part of.
+-- # Class: Role_hasPart
+--     * Slot: Role_id Description: Autocreated FK slot
+--     * Slot: hasPart_id Description: A concept that is a part of this concept.
+-- # Class: Role_references
+--     * Slot: Role_id Description: Autocreated FK slot
+--     * Slot: references_id Description: A concept or resource this concept refers to.
+-- # Class: Role_dependsOn
+--     * Slot: Role_id Description: Autocreated FK slot
+--     * Slot: dependsOn_id Description: A concept this concept depends on.
+-- # Class: Role_derivedFrom
+--     * Slot: Role_id Description: Autocreated FK slot
+--     * Slot: derivedFrom_id Description: An entity this concept was derived from (provenance).
+-- # Class: Role_about
+--     * Slot: Role_id Description: Autocreated FK slot
+--     * Slot: about_id Description: The subject matter this concept is about.
+-- # Class: Role_sameAs
+--     * Slot: Role_id Description: Autocreated FK slot
+--     * Slot: sameAs_id Description: An IRI asserting this concept is the same entity as another.
+-- # Class: Role_relatedTo
+--     * Slot: Role_id Description: Autocreated FK slot
+--     * Slot: relatedTo_id Description: A generic association to another concept.
+-- # Class: Role_definedBy
+--     * Slot: Role_id Description: Autocreated FK slot
+--     * Slot: definedBy_id Description: A resource that formally defines this concept.
+-- # Class: Role_source
+--     * Slot: Role_id Description: Autocreated FK slot
+--     * Slot: source_id Description: A resource from which this concept is derived or sourced.
+-- # Class: Person_tags
+--     * Slot: Person_id Description: Autocreated FK slot
+--     * Slot: tags Description: Short cross-cutting keywords for categorization.
+-- # Class: Person_isPartOf
+--     * Slot: Person_id Description: Autocreated FK slot
+--     * Slot: isPartOf_id Description: The target concept that this concept is a part of.
+-- # Class: Person_hasPart
+--     * Slot: Person_id Description: Autocreated FK slot
+--     * Slot: hasPart_id Description: A concept that is a part of this concept.
+-- # Class: Person_references
+--     * Slot: Person_id Description: Autocreated FK slot
+--     * Slot: references_id Description: A concept or resource this concept refers to.
+-- # Class: Person_dependsOn
+--     * Slot: Person_id Description: Autocreated FK slot
+--     * Slot: dependsOn_id Description: A concept this concept depends on.
+-- # Class: Person_derivedFrom
+--     * Slot: Person_id Description: Autocreated FK slot
+--     * Slot: derivedFrom_id Description: An entity this concept was derived from (provenance).
+-- # Class: Person_about
+--     * Slot: Person_id Description: Autocreated FK slot
+--     * Slot: about_id Description: The subject matter this concept is about.
+-- # Class: Person_sameAs
+--     * Slot: Person_id Description: Autocreated FK slot
+--     * Slot: sameAs_id Description: An IRI asserting this concept is the same entity as another.
+-- # Class: Person_relatedTo
+--     * Slot: Person_id Description: Autocreated FK slot
+--     * Slot: relatedTo_id Description: A generic association to another concept.
+-- # Class: Person_definedBy
+--     * Slot: Person_id Description: Autocreated FK slot
+--     * Slot: definedBy_id Description: A resource that formally defines this concept.
+-- # Class: Person_source
+--     * Slot: Person_id Description: Autocreated FK slot
+--     * Slot: source_id Description: A resource from which this concept is derived or sourced.
+-- # Class: Organization_tags
+--     * Slot: Organization_id Description: Autocreated FK slot
+--     * Slot: tags Description: Short cross-cutting keywords for categorization.
+-- # Class: Organization_isPartOf
+--     * Slot: Organization_id Description: Autocreated FK slot
+--     * Slot: isPartOf_id Description: The target concept that this concept is a part of.
+-- # Class: Organization_hasPart
+--     * Slot: Organization_id Description: Autocreated FK slot
+--     * Slot: hasPart_id Description: A concept that is a part of this concept.
+-- # Class: Organization_references
+--     * Slot: Organization_id Description: Autocreated FK slot
+--     * Slot: references_id Description: A concept or resource this concept refers to.
+-- # Class: Organization_dependsOn
+--     * Slot: Organization_id Description: Autocreated FK slot
+--     * Slot: dependsOn_id Description: A concept this concept depends on.
+-- # Class: Organization_derivedFrom
+--     * Slot: Organization_id Description: Autocreated FK slot
+--     * Slot: derivedFrom_id Description: An entity this concept was derived from (provenance).
+-- # Class: Organization_about
+--     * Slot: Organization_id Description: Autocreated FK slot
+--     * Slot: about_id Description: The subject matter this concept is about.
+-- # Class: Organization_sameAs
+--     * Slot: Organization_id Description: Autocreated FK slot
+--     * Slot: sameAs_id Description: An IRI asserting this concept is the same entity as another.
+-- # Class: Organization_relatedTo
+--     * Slot: Organization_id Description: Autocreated FK slot
+--     * Slot: relatedTo_id Description: A generic association to another concept.
+-- # Class: Organization_definedBy
+--     * Slot: Organization_id Description: Autocreated FK slot
+--     * Slot: definedBy_id Description: A resource that formally defines this concept.
+-- # Class: Organization_source
+--     * Slot: Organization_id Description: Autocreated FK slot
+--     * Slot: source_id Description: A resource from which this concept is derived or sourced.
+
+CREATE TABLE "KnowledgeBundle" (
+	id INTEGER NOT NULL,
+	lokf_version TEXT,
+	okf_version TEXT,
+	base_iri TEXT,
+	context TEXT,
+	title TEXT,
+	description TEXT,
+	license TEXT,
+	publisher_id TEXT,
+	PRIMARY KEY (id),
+	FOREIGN KEY(publisher_id) REFERENCES "Agent" (id)
+);
+CREATE INDEX "ix_KnowledgeBundle_id" ON "KnowledgeBundle" (id);
+
+CREATE TABLE "Concept" (
+	id TEXT NOT NULL,
+	type TEXT NOT NULL,
+	title TEXT,
+	description TEXT,
+	resource TEXT,
+	timestamp DATETIME,
+	created DATETIME,
+	version TEXT,
+	license TEXT,
+	body TEXT,
+	"KnowledgeBundle_id" INTEGER,
+	PRIMARY KEY (id),
+	FOREIGN KEY("KnowledgeBundle_id") REFERENCES "KnowledgeBundle" (id)
+);
+CREATE INDEX "ix_Concept_id" ON "Concept" (id);
+
+CREATE TABLE "Dataset" (
+	id TEXT NOT NULL,
+	type TEXT NOT NULL,
+	title TEXT,
+	description TEXT,
+	resource TEXT,
+	timestamp DATETIME,
+	created DATETIME,
+	version TEXT,
+	license TEXT,
+	body TEXT,
+	PRIMARY KEY (id)
+);
+CREATE INDEX "ix_Dataset_id" ON "Dataset" (id);
+
+CREATE TABLE "Table" (
+	id TEXT NOT NULL,
+	type TEXT NOT NULL,
+	title TEXT,
+	description TEXT,
+	resource TEXT,
+	timestamp DATETIME,
+	created DATETIME,
+	version TEXT,
+	license TEXT,
+	body TEXT,
+	PRIMARY KEY (id)
+);
+CREATE INDEX "ix_Table_id" ON "Table" (id);
+
+CREATE TABLE "Metric" (
+	unit TEXT,
+	formula TEXT,
+	id TEXT NOT NULL,
+	type TEXT NOT NULL,
+	title TEXT,
+	description TEXT,
+	resource TEXT,
+	timestamp DATETIME,
+	created DATETIME,
+	version TEXT,
+	license TEXT,
+	body TEXT,
+	PRIMARY KEY (id)
+);
+CREATE INDEX "ix_Metric_id" ON "Metric" (id);
+
+CREATE TABLE "Service" (
+	endpoint TEXT,
+	http_method TEXT,
+	documentation TEXT,
+	id TEXT NOT NULL,
+	type TEXT NOT NULL,
+	title TEXT,
+	description TEXT,
+	resource TEXT,
+	timestamp DATETIME,
+	created DATETIME,
+	version TEXT,
+	license TEXT,
+	body TEXT,
+	PRIMARY KEY (id)
+);
+CREATE INDEX "ix_Service_id" ON "Service" (id);
+
+CREATE TABLE "Playbook" (
+	id TEXT NOT NULL,
+	type TEXT NOT NULL,
+	title TEXT,
+	description TEXT,
+	resource TEXT,
+	timestamp DATETIME,
+	created DATETIME,
+	version TEXT,
+	license TEXT,
+	body TEXT,
+	PRIMARY KEY (id)
+);
+CREATE INDEX "ix_Playbook_id" ON "Playbook" (id);
+
+CREATE TABLE "Policy" (
+	id TEXT NOT NULL,
+	type TEXT NOT NULL,
+	title TEXT,
+	description TEXT,
+	resource TEXT,
+	timestamp DATETIME,
+	created DATETIME,
+	version TEXT,
+	license TEXT,
+	body TEXT,
+	PRIMARY KEY (id)
+);
+CREATE INDEX "ix_Policy_id" ON "Policy" (id);
+
+CREATE TABLE "GlossaryTerm" (
+	definition TEXT,
+	abbreviation TEXT,
+	id TEXT NOT NULL,
+	type TEXT NOT NULL,
+	title TEXT,
+	description TEXT,
+	resource TEXT,
+	timestamp DATETIME,
+	created DATETIME,
+	version TEXT,
+	license TEXT,
+	body TEXT,
+	PRIMARY KEY (id)
+);
+CREATE INDEX "ix_GlossaryTerm_id" ON "GlossaryTerm" (id);
+
+CREATE TABLE "Reference" (
+	id TEXT NOT NULL,
+	type TEXT NOT NULL,
+	title TEXT,
+	description TEXT,
+	resource TEXT,
+	timestamp DATETIME,
+	created DATETIME,
+	version TEXT,
+	license TEXT,
+	body TEXT,
+	PRIMARY KEY (id)
+);
+CREATE INDEX "ix_Reference_id" ON "Reference" (id);
+
+CREATE TABLE "Document" (
+	id TEXT NOT NULL,
+	type TEXT NOT NULL,
+	title TEXT,
+	description TEXT,
+	resource TEXT,
+	timestamp DATETIME,
+	created DATETIME,
+	version TEXT,
+	license TEXT,
+	body TEXT,
+	PRIMARY KEY (id)
+);
+CREATE INDEX "ix_Document_id" ON "Document" (id);
+
+CREATE TABLE "Role" (
+	"roleName" TEXT,
+	"startDate" TEXT,
+	"endDate" TEXT,
+	id TEXT NOT NULL,
+	type TEXT NOT NULL,
+	title TEXT,
+	description TEXT,
+	resource TEXT,
+	timestamp DATETIME,
+	created DATETIME,
+	version TEXT,
+	license TEXT,
+	body TEXT,
+	PRIMARY KEY (id)
+);
+CREATE INDEX "ix_Role_id" ON "Role" (id);
+
+CREATE TABLE "Agent" (
+	type TEXT NOT NULL,
+	id TEXT NOT NULL,
+	name TEXT,
+	email TEXT,
+	"Concept_id" TEXT,
+	"Dataset_id" TEXT,
+	"Table_id" TEXT,
+	"Metric_id" TEXT,
+	"Service_id" TEXT,
+	"Playbook_id" TEXT,
+	"Policy_id" TEXT,
+	"GlossaryTerm_id" TEXT,
+	"Reference_id" TEXT,
+	"Document_id" TEXT,
+	"Role_id" TEXT,
+	"Person_id" TEXT,
+	"Organization_id" TEXT,
+	PRIMARY KEY (id),
+	FOREIGN KEY("Concept_id") REFERENCES "Concept" (id),
+	FOREIGN KEY("Dataset_id") REFERENCES "Dataset" (id),
+	FOREIGN KEY("Table_id") REFERENCES "Table" (id),
+	FOREIGN KEY("Metric_id") REFERENCES "Metric" (id),
+	FOREIGN KEY("Service_id") REFERENCES "Service" (id),
+	FOREIGN KEY("Playbook_id") REFERENCES "Playbook" (id),
+	FOREIGN KEY("Policy_id") REFERENCES "Policy" (id),
+	FOREIGN KEY("GlossaryTerm_id") REFERENCES "GlossaryTerm" (id),
+	FOREIGN KEY("Reference_id") REFERENCES "Reference" (id),
+	FOREIGN KEY("Document_id") REFERENCES "Document" (id),
+	FOREIGN KEY("Role_id") REFERENCES "Role" (id),
+	FOREIGN KEY("Person_id") REFERENCES "Person" (id),
+	FOREIGN KEY("Organization_id") REFERENCES "Organization" (id)
+);
+CREATE INDEX "ix_Agent_id" ON "Agent" (id);
+
+CREATE TABLE "Person" (
+	id TEXT NOT NULL,
+	type TEXT NOT NULL,
+	title TEXT,
+	description TEXT,
+	resource TEXT,
+	timestamp DATETIME,
+	created DATETIME,
+	version TEXT,
+	license TEXT,
+	body TEXT,
+	name TEXT,
+	email TEXT,
+	PRIMARY KEY (id)
+);
+CREATE INDEX "ix_Person_id" ON "Person" (id);
+
+CREATE TABLE "Organization" (
+	id TEXT NOT NULL,
+	type TEXT NOT NULL,
+	title TEXT,
+	description TEXT,
+	resource TEXT,
+	timestamp DATETIME,
+	created DATETIME,
+	version TEXT,
+	license TEXT,
+	body TEXT,
+	name TEXT,
+	email TEXT,
+	PRIMARY KEY (id)
+);
+CREATE INDEX "ix_Organization_id" ON "Organization" (id);
+
+CREATE TABLE "Field" (
+	id INTEGER NOT NULL,
+	name TEXT,
+	datatype VARCHAR(8),
+	description TEXT,
+	unit TEXT,
+	is_key BOOLEAN,
+	constraints TEXT,
+	"Dataset_id" TEXT,
+	"Table_id" TEXT,
+	PRIMARY KEY (id),
+	FOREIGN KEY("Dataset_id") REFERENCES "Dataset" (id),
+	FOREIGN KEY("Table_id") REFERENCES "Table" (id)
+);
+CREATE INDEX "ix_Field_id" ON "Field" (id);
+
+CREATE TABLE "Distribution" (
+	id INTEGER NOT NULL,
+	name TEXT,
+	description TEXT,
+	access_url TEXT,
+	media_type TEXT,
+	"Dataset_id" TEXT,
+	"Table_id" TEXT,
+	PRIMARY KEY (id),
+	FOREIGN KEY("Dataset_id") REFERENCES "Dataset" (id),
+	FOREIGN KEY("Table_id") REFERENCES "Table" (id)
+);
+CREATE INDEX "ix_Distribution_id" ON "Distribution" (id);
+
+CREATE TABLE "Relation" (
+	id INTEGER NOT NULL,
+	predicate VARCHAR(15) NOT NULL,
+	target TEXT NOT NULL,
+	relation_label TEXT,
+	"Concept_id" TEXT,
+	"Dataset_id" TEXT,
+	"Table_id" TEXT,
+	"Metric_id" TEXT,
+	"Service_id" TEXT,
+	"Playbook_id" TEXT,
+	"Policy_id" TEXT,
+	"GlossaryTerm_id" TEXT,
+	"Reference_id" TEXT,
+	"Document_id" TEXT,
+	"Role_id" TEXT,
+	"Person_id" TEXT,
+	"Organization_id" TEXT,
+	PRIMARY KEY (id),
+	FOREIGN KEY(target) REFERENCES "Concept" (id),
+	FOREIGN KEY("Concept_id") REFERENCES "Concept" (id),
+	FOREIGN KEY("Dataset_id") REFERENCES "Dataset" (id),
+	FOREIGN KEY("Table_id") REFERENCES "Table" (id),
+	FOREIGN KEY("Metric_id") REFERENCES "Metric" (id),
+	FOREIGN KEY("Service_id") REFERENCES "Service" (id),
+	FOREIGN KEY("Playbook_id") REFERENCES "Playbook" (id),
+	FOREIGN KEY("Policy_id") REFERENCES "Policy" (id),
+	FOREIGN KEY("GlossaryTerm_id") REFERENCES "GlossaryTerm" (id),
+	FOREIGN KEY("Reference_id") REFERENCES "Reference" (id),
+	FOREIGN KEY("Document_id") REFERENCES "Document" (id),
+	FOREIGN KEY("Role_id") REFERENCES "Role" (id),
+	FOREIGN KEY("Person_id") REFERENCES "Person" (id),
+	FOREIGN KEY("Organization_id") REFERENCES "Organization" (id)
+);
+CREATE INDEX "ix_Relation_id" ON "Relation" (id);
+
+CREATE TABLE "Citation" (
+	id INTEGER NOT NULL,
+	title TEXT,
+	url TEXT,
+	description TEXT,
+	"Concept_id" TEXT,
+	"Dataset_id" TEXT,
+	"Table_id" TEXT,
+	"Metric_id" TEXT,
+	"Service_id" TEXT,
+	"Playbook_id" TEXT,
+	"Policy_id" TEXT,
+	"GlossaryTerm_id" TEXT,
+	"Reference_id" TEXT,
+	"Document_id" TEXT,
+	"Role_id" TEXT,
+	"Person_id" TEXT,
+	"Organization_id" TEXT,
+	PRIMARY KEY (id),
+	FOREIGN KEY("Concept_id") REFERENCES "Concept" (id),
+	FOREIGN KEY("Dataset_id") REFERENCES "Dataset" (id),
+	FOREIGN KEY("Table_id") REFERENCES "Table" (id),
+	FOREIGN KEY("Metric_id") REFERENCES "Metric" (id),
+	FOREIGN KEY("Service_id") REFERENCES "Service" (id),
+	FOREIGN KEY("Playbook_id") REFERENCES "Playbook" (id),
+	FOREIGN KEY("Policy_id") REFERENCES "Policy" (id),
+	FOREIGN KEY("GlossaryTerm_id") REFERENCES "GlossaryTerm" (id),
+	FOREIGN KEY("Reference_id") REFERENCES "Reference" (id),
+	FOREIGN KEY("Document_id") REFERENCES "Document" (id),
+	FOREIGN KEY("Role_id") REFERENCES "Role" (id),
+	FOREIGN KEY("Person_id") REFERENCES "Person" (id),
+	FOREIGN KEY("Organization_id") REFERENCES "Organization" (id)
+);
+CREATE INDEX "ix_Citation_id" ON "Citation" (id);
+
+CREATE TABLE "Concept_tags" (
+	"Concept_id" TEXT,
+	tags TEXT,
+	PRIMARY KEY ("Concept_id", tags),
+	FOREIGN KEY("Concept_id") REFERENCES "Concept" (id)
+);
+CREATE INDEX "ix_Concept_tags_Concept_id" ON "Concept_tags" ("Concept_id");
+CREATE INDEX "ix_Concept_tags_tags" ON "Concept_tags" (tags);
+
+CREATE TABLE "Concept_isPartOf" (
+	"Concept_id" TEXT,
+	"isPartOf_id" TEXT,
+	PRIMARY KEY ("Concept_id", "isPartOf_id"),
+	FOREIGN KEY("Concept_id") REFERENCES "Concept" (id),
+	FOREIGN KEY("isPartOf_id") REFERENCES "Concept" (id)
+);
+CREATE INDEX "ix_Concept_isPartOf_isPartOf_id" ON "Concept_isPartOf" ("isPartOf_id");
+CREATE INDEX "ix_Concept_isPartOf_Concept_id" ON "Concept_isPartOf" ("Concept_id");
+
+CREATE TABLE "Concept_hasPart" (
+	"Concept_id" TEXT,
+	"hasPart_id" TEXT,
+	PRIMARY KEY ("Concept_id", "hasPart_id"),
+	FOREIGN KEY("Concept_id") REFERENCES "Concept" (id),
+	FOREIGN KEY("hasPart_id") REFERENCES "Concept" (id)
+);
+CREATE INDEX "ix_Concept_hasPart_Concept_id" ON "Concept_hasPart" ("Concept_id");
+CREATE INDEX "ix_Concept_hasPart_hasPart_id" ON "Concept_hasPart" ("hasPart_id");
+
+CREATE TABLE "Concept_references" (
+	"Concept_id" TEXT,
+	references_id TEXT,
+	PRIMARY KEY ("Concept_id", references_id),
+	FOREIGN KEY("Concept_id") REFERENCES "Concept" (id),
+	FOREIGN KEY(references_id) REFERENCES "Concept" (id)
+);
+CREATE INDEX "ix_Concept_references_Concept_id" ON "Concept_references" ("Concept_id");
+CREATE INDEX "ix_Concept_references_references_id" ON "Concept_references" (references_id);
+
+CREATE TABLE "Concept_dependsOn" (
+	"Concept_id" TEXT,
+	"dependsOn_id" TEXT,
+	PRIMARY KEY ("Concept_id", "dependsOn_id"),
+	FOREIGN KEY("Concept_id") REFERENCES "Concept" (id),
+	FOREIGN KEY("dependsOn_id") REFERENCES "Concept" (id)
+);
+CREATE INDEX "ix_Concept_dependsOn_dependsOn_id" ON "Concept_dependsOn" ("dependsOn_id");
+CREATE INDEX "ix_Concept_dependsOn_Concept_id" ON "Concept_dependsOn" ("Concept_id");
+
+CREATE TABLE "Concept_derivedFrom" (
+	"Concept_id" TEXT,
+	"derivedFrom_id" TEXT,
+	PRIMARY KEY ("Concept_id", "derivedFrom_id"),
+	FOREIGN KEY("Concept_id") REFERENCES "Concept" (id),
+	FOREIGN KEY("derivedFrom_id") REFERENCES "Concept" (id)
+);
+CREATE INDEX "ix_Concept_derivedFrom_Concept_id" ON "Concept_derivedFrom" ("Concept_id");
+CREATE INDEX "ix_Concept_derivedFrom_derivedFrom_id" ON "Concept_derivedFrom" ("derivedFrom_id");
+
+CREATE TABLE "Concept_about" (
+	"Concept_id" TEXT,
+	about_id TEXT,
+	PRIMARY KEY ("Concept_id", about_id),
+	FOREIGN KEY("Concept_id") REFERENCES "Concept" (id),
+	FOREIGN KEY(about_id) REFERENCES "Concept" (id)
+);
+CREATE INDEX "ix_Concept_about_about_id" ON "Concept_about" (about_id);
+CREATE INDEX "ix_Concept_about_Concept_id" ON "Concept_about" ("Concept_id");
+
+CREATE TABLE "Concept_sameAs" (
+	"Concept_id" TEXT,
+	"sameAs_id" TEXT,
+	PRIMARY KEY ("Concept_id", "sameAs_id"),
+	FOREIGN KEY("Concept_id") REFERENCES "Concept" (id),
+	FOREIGN KEY("sameAs_id") REFERENCES "Concept" (id)
+);
+CREATE INDEX "ix_Concept_sameAs_Concept_id" ON "Concept_sameAs" ("Concept_id");
+CREATE INDEX "ix_Concept_sameAs_sameAs_id" ON "Concept_sameAs" ("sameAs_id");
+
+CREATE TABLE "Concept_relatedTo" (
+	"Concept_id" TEXT,
+	"relatedTo_id" TEXT,
+	PRIMARY KEY ("Concept_id", "relatedTo_id"),
+	FOREIGN KEY("Concept_id") REFERENCES "Concept" (id),
+	FOREIGN KEY("relatedTo_id") REFERENCES "Concept" (id)
+);
+CREATE INDEX "ix_Concept_relatedTo_relatedTo_id" ON "Concept_relatedTo" ("relatedTo_id");
+CREATE INDEX "ix_Concept_relatedTo_Concept_id" ON "Concept_relatedTo" ("Concept_id");
+
+CREATE TABLE "Concept_definedBy" (
+	"Concept_id" TEXT,
+	"definedBy_id" TEXT,
+	PRIMARY KEY ("Concept_id", "definedBy_id"),
+	FOREIGN KEY("Concept_id") REFERENCES "Concept" (id),
+	FOREIGN KEY("definedBy_id") REFERENCES "Concept" (id)
+);
+CREATE INDEX "ix_Concept_definedBy_definedBy_id" ON "Concept_definedBy" ("definedBy_id");
+CREATE INDEX "ix_Concept_definedBy_Concept_id" ON "Concept_definedBy" ("Concept_id");
+
+CREATE TABLE "Concept_source" (
+	"Concept_id" TEXT,
+	source_id TEXT,
+	PRIMARY KEY ("Concept_id", source_id),
+	FOREIGN KEY("Concept_id") REFERENCES "Concept" (id),
+	FOREIGN KEY(source_id) REFERENCES "Concept" (id)
+);
+CREATE INDEX "ix_Concept_source_Concept_id" ON "Concept_source" ("Concept_id");
+CREATE INDEX "ix_Concept_source_source_id" ON "Concept_source" (source_id);
+
+CREATE TABLE "Dataset_tags" (
+	"Dataset_id" TEXT,
+	tags TEXT,
+	PRIMARY KEY ("Dataset_id", tags),
+	FOREIGN KEY("Dataset_id") REFERENCES "Dataset" (id)
+);
+CREATE INDEX "ix_Dataset_tags_tags" ON "Dataset_tags" (tags);
+CREATE INDEX "ix_Dataset_tags_Dataset_id" ON "Dataset_tags" ("Dataset_id");
+
+CREATE TABLE "Dataset_isPartOf" (
+	"Dataset_id" TEXT,
+	"isPartOf_id" TEXT,
+	PRIMARY KEY ("Dataset_id", "isPartOf_id"),
+	FOREIGN KEY("Dataset_id") REFERENCES "Dataset" (id),
+	FOREIGN KEY("isPartOf_id") REFERENCES "Concept" (id)
+);
+CREATE INDEX "ix_Dataset_isPartOf_isPartOf_id" ON "Dataset_isPartOf" ("isPartOf_id");
+CREATE INDEX "ix_Dataset_isPartOf_Dataset_id" ON "Dataset_isPartOf" ("Dataset_id");
+
+CREATE TABLE "Dataset_hasPart" (
+	"Dataset_id" TEXT,
+	"hasPart_id" TEXT,
+	PRIMARY KEY ("Dataset_id", "hasPart_id"),
+	FOREIGN KEY("Dataset_id") REFERENCES "Dataset" (id),
+	FOREIGN KEY("hasPart_id") REFERENCES "Concept" (id)
+);
+CREATE INDEX "ix_Dataset_hasPart_hasPart_id" ON "Dataset_hasPart" ("hasPart_id");
+CREATE INDEX "ix_Dataset_hasPart_Dataset_id" ON "Dataset_hasPart" ("Dataset_id");
+
+CREATE TABLE "Dataset_references" (
+	"Dataset_id" TEXT,
+	references_id TEXT,
+	PRIMARY KEY ("Dataset_id", references_id),
+	FOREIGN KEY("Dataset_id") REFERENCES "Dataset" (id),
+	FOREIGN KEY(references_id) REFERENCES "Concept" (id)
+);
+CREATE INDEX "ix_Dataset_references_references_id" ON "Dataset_references" (references_id);
+CREATE INDEX "ix_Dataset_references_Dataset_id" ON "Dataset_references" ("Dataset_id");
+
+CREATE TABLE "Dataset_dependsOn" (
+	"Dataset_id" TEXT,
+	"dependsOn_id" TEXT,
+	PRIMARY KEY ("Dataset_id", "dependsOn_id"),
+	FOREIGN KEY("Dataset_id") REFERENCES "Dataset" (id),
+	FOREIGN KEY("dependsOn_id") REFERENCES "Concept" (id)
+);
+CREATE INDEX "ix_Dataset_dependsOn_Dataset_id" ON "Dataset_dependsOn" ("Dataset_id");
+CREATE INDEX "ix_Dataset_dependsOn_dependsOn_id" ON "Dataset_dependsOn" ("dependsOn_id");
+
+CREATE TABLE "Dataset_derivedFrom" (
+	"Dataset_id" TEXT,
+	"derivedFrom_id" TEXT,
+	PRIMARY KEY ("Dataset_id", "derivedFrom_id"),
+	FOREIGN KEY("Dataset_id") REFERENCES "Dataset" (id),
+	FOREIGN KEY("derivedFrom_id") REFERENCES "Concept" (id)
+);
+CREATE INDEX "ix_Dataset_derivedFrom_Dataset_id" ON "Dataset_derivedFrom" ("Dataset_id");
+CREATE INDEX "ix_Dataset_derivedFrom_derivedFrom_id" ON "Dataset_derivedFrom" ("derivedFrom_id");
+
+CREATE TABLE "Dataset_about" (
+	"Dataset_id" TEXT,
+	about_id TEXT,
+	PRIMARY KEY ("Dataset_id", about_id),
+	FOREIGN KEY("Dataset_id") REFERENCES "Dataset" (id),
+	FOREIGN KEY(about_id) REFERENCES "Concept" (id)
+);
+CREATE INDEX "ix_Dataset_about_Dataset_id" ON "Dataset_about" ("Dataset_id");
+CREATE INDEX "ix_Dataset_about_about_id" ON "Dataset_about" (about_id);
+
+CREATE TABLE "Dataset_sameAs" (
+	"Dataset_id" TEXT,
+	"sameAs_id" TEXT,
+	PRIMARY KEY ("Dataset_id", "sameAs_id"),
+	FOREIGN KEY("Dataset_id") REFERENCES "Dataset" (id),
+	FOREIGN KEY("sameAs_id") REFERENCES "Concept" (id)
+);
+CREATE INDEX "ix_Dataset_sameAs_sameAs_id" ON "Dataset_sameAs" ("sameAs_id");
+CREATE INDEX "ix_Dataset_sameAs_Dataset_id" ON "Dataset_sameAs" ("Dataset_id");
+
+CREATE TABLE "Dataset_relatedTo" (
+	"Dataset_id" TEXT,
+	"relatedTo_id" TEXT,
+	PRIMARY KEY ("Dataset_id", "relatedTo_id"),
+	FOREIGN KEY("Dataset_id") REFERENCES "Dataset" (id),
+	FOREIGN KEY("relatedTo_id") REFERENCES "Concept" (id)
+);
+CREATE INDEX "ix_Dataset_relatedTo_Dataset_id" ON "Dataset_relatedTo" ("Dataset_id");
+CREATE INDEX "ix_Dataset_relatedTo_relatedTo_id" ON "Dataset_relatedTo" ("relatedTo_id");
+
+CREATE TABLE "Dataset_definedBy" (
+	"Dataset_id" TEXT,
+	"definedBy_id" TEXT,
+	PRIMARY KEY ("Dataset_id", "definedBy_id"),
+	FOREIGN KEY("Dataset_id") REFERENCES "Dataset" (id),
+	FOREIGN KEY("definedBy_id") REFERENCES "Concept" (id)
+);
+CREATE INDEX "ix_Dataset_definedBy_definedBy_id" ON "Dataset_definedBy" ("definedBy_id");
+CREATE INDEX "ix_Dataset_definedBy_Dataset_id" ON "Dataset_definedBy" ("Dataset_id");
+
+CREATE TABLE "Dataset_source" (
+	"Dataset_id" TEXT,
+	source_id TEXT,
+	PRIMARY KEY ("Dataset_id", source_id),
+	FOREIGN KEY("Dataset_id") REFERENCES "Dataset" (id),
+	FOREIGN KEY(source_id) REFERENCES "Concept" (id)
+);
+CREATE INDEX "ix_Dataset_source_Dataset_id" ON "Dataset_source" ("Dataset_id");
+CREATE INDEX "ix_Dataset_source_source_id" ON "Dataset_source" (source_id);
+
+CREATE TABLE "Table_tags" (
+	"Table_id" TEXT,
+	tags TEXT,
+	PRIMARY KEY ("Table_id", tags),
+	FOREIGN KEY("Table_id") REFERENCES "Table" (id)
+);
+CREATE INDEX "ix_Table_tags_Table_id" ON "Table_tags" ("Table_id");
+CREATE INDEX "ix_Table_tags_tags" ON "Table_tags" (tags);
+
+CREATE TABLE "Table_isPartOf" (
+	"Table_id" TEXT,
+	"isPartOf_id" TEXT,
+	PRIMARY KEY ("Table_id", "isPartOf_id"),
+	FOREIGN KEY("Table_id") REFERENCES "Table" (id),
+	FOREIGN KEY("isPartOf_id") REFERENCES "Concept" (id)
+);
+CREATE INDEX "ix_Table_isPartOf_Table_id" ON "Table_isPartOf" ("Table_id");
+CREATE INDEX "ix_Table_isPartOf_isPartOf_id" ON "Table_isPartOf" ("isPartOf_id");
+
+CREATE TABLE "Table_hasPart" (
+	"Table_id" TEXT,
+	"hasPart_id" TEXT,
+	PRIMARY KEY ("Table_id", "hasPart_id"),
+	FOREIGN KEY("Table_id") REFERENCES "Table" (id),
+	FOREIGN KEY("hasPart_id") REFERENCES "Concept" (id)
+);
+CREATE INDEX "ix_Table_hasPart_Table_id" ON "Table_hasPart" ("Table_id");
+CREATE INDEX "ix_Table_hasPart_hasPart_id" ON "Table_hasPart" ("hasPart_id");
+
+CREATE TABLE "Table_references" (
+	"Table_id" TEXT,
+	references_id TEXT,
+	PRIMARY KEY ("Table_id", references_id),
+	FOREIGN KEY("Table_id") REFERENCES "Table" (id),
+	FOREIGN KEY(references_id) REFERENCES "Concept" (id)
+);
+CREATE INDEX "ix_Table_references_references_id" ON "Table_references" (references_id);
+CREATE INDEX "ix_Table_references_Table_id" ON "Table_references" ("Table_id");
+
+CREATE TABLE "Table_dependsOn" (
+	"Table_id" TEXT,
+	"dependsOn_id" TEXT,
+	PRIMARY KEY ("Table_id", "dependsOn_id"),
+	FOREIGN KEY("Table_id") REFERENCES "Table" (id),
+	FOREIGN KEY("dependsOn_id") REFERENCES "Concept" (id)
+);
+CREATE INDEX "ix_Table_dependsOn_Table_id" ON "Table_dependsOn" ("Table_id");
+CREATE INDEX "ix_Table_dependsOn_dependsOn_id" ON "Table_dependsOn" ("dependsOn_id");
+
+CREATE TABLE "Table_derivedFrom" (
+	"Table_id" TEXT,
+	"derivedFrom_id" TEXT,
+	PRIMARY KEY ("Table_id", "derivedFrom_id"),
+	FOREIGN KEY("Table_id") REFERENCES "Table" (id),
+	FOREIGN KEY("derivedFrom_id") REFERENCES "Concept" (id)
+);
+CREATE INDEX "ix_Table_derivedFrom_Table_id" ON "Table_derivedFrom" ("Table_id");
+CREATE INDEX "ix_Table_derivedFrom_derivedFrom_id" ON "Table_derivedFrom" ("derivedFrom_id");
+
+CREATE TABLE "Table_about" (
+	"Table_id" TEXT,
+	about_id TEXT,
+	PRIMARY KEY ("Table_id", about_id),
+	FOREIGN KEY("Table_id") REFERENCES "Table" (id),
+	FOREIGN KEY(about_id) REFERENCES "Concept" (id)
+);
+CREATE INDEX "ix_Table_about_about_id" ON "Table_about" (about_id);
+CREATE INDEX "ix_Table_about_Table_id" ON "Table_about" ("Table_id");
+
+CREATE TABLE "Table_sameAs" (
+	"Table_id" TEXT,
+	"sameAs_id" TEXT,
+	PRIMARY KEY ("Table_id", "sameAs_id"),
+	FOREIGN KEY("Table_id") REFERENCES "Table" (id),
+	FOREIGN KEY("sameAs_id") REFERENCES "Concept" (id)
+);
+CREATE INDEX "ix_Table_sameAs_Table_id" ON "Table_sameAs" ("Table_id");
+CREATE INDEX "ix_Table_sameAs_sameAs_id" ON "Table_sameAs" ("sameAs_id");
+
+CREATE TABLE "Table_relatedTo" (
+	"Table_id" TEXT,
+	"relatedTo_id" TEXT,
+	PRIMARY KEY ("Table_id", "relatedTo_id"),
+	FOREIGN KEY("Table_id") REFERENCES "Table" (id),
+	FOREIGN KEY("relatedTo_id") REFERENCES "Concept" (id)
+);
+CREATE INDEX "ix_Table_relatedTo_relatedTo_id" ON "Table_relatedTo" ("relatedTo_id");
+CREATE INDEX "ix_Table_relatedTo_Table_id" ON "Table_relatedTo" ("Table_id");
+
+CREATE TABLE "Table_definedBy" (
+	"Table_id" TEXT,
+	"definedBy_id" TEXT,
+	PRIMARY KEY ("Table_id", "definedBy_id"),
+	FOREIGN KEY("Table_id") REFERENCES "Table" (id),
+	FOREIGN KEY("definedBy_id") REFERENCES "Concept" (id)
+);
+CREATE INDEX "ix_Table_definedBy_definedBy_id" ON "Table_definedBy" ("definedBy_id");
+CREATE INDEX "ix_Table_definedBy_Table_id" ON "Table_definedBy" ("Table_id");
+
+CREATE TABLE "Table_source" (
+	"Table_id" TEXT,
+	source_id TEXT,
+	PRIMARY KEY ("Table_id", source_id),
+	FOREIGN KEY("Table_id") REFERENCES "Table" (id),
+	FOREIGN KEY(source_id) REFERENCES "Concept" (id)
+);
+CREATE INDEX "ix_Table_source_source_id" ON "Table_source" (source_id);
+CREATE INDEX "ix_Table_source_Table_id" ON "Table_source" ("Table_id");
+
+CREATE TABLE "Metric_measures" (
+	"Metric_id" TEXT,
+	measures_id TEXT,
+	PRIMARY KEY ("Metric_id", measures_id),
+	FOREIGN KEY("Metric_id") REFERENCES "Metric" (id),
+	FOREIGN KEY(measures_id) REFERENCES "Concept" (id)
+);
+CREATE INDEX "ix_Metric_measures_measures_id" ON "Metric_measures" (measures_id);
+CREATE INDEX "ix_Metric_measures_Metric_id" ON "Metric_measures" ("Metric_id");
+
+CREATE TABLE "Metric_tags" (
+	"Metric_id" TEXT,
+	tags TEXT,
+	PRIMARY KEY ("Metric_id", tags),
+	FOREIGN KEY("Metric_id") REFERENCES "Metric" (id)
+);
+CREATE INDEX "ix_Metric_tags_tags" ON "Metric_tags" (tags);
+CREATE INDEX "ix_Metric_tags_Metric_id" ON "Metric_tags" ("Metric_id");
+
+CREATE TABLE "Metric_isPartOf" (
+	"Metric_id" TEXT,
+	"isPartOf_id" TEXT,
+	PRIMARY KEY ("Metric_id", "isPartOf_id"),
+	FOREIGN KEY("Metric_id") REFERENCES "Metric" (id),
+	FOREIGN KEY("isPartOf_id") REFERENCES "Concept" (id)
+);
+CREATE INDEX "ix_Metric_isPartOf_isPartOf_id" ON "Metric_isPartOf" ("isPartOf_id");
+CREATE INDEX "ix_Metric_isPartOf_Metric_id" ON "Metric_isPartOf" ("Metric_id");
+
+CREATE TABLE "Metric_hasPart" (
+	"Metric_id" TEXT,
+	"hasPart_id" TEXT,
+	PRIMARY KEY ("Metric_id", "hasPart_id"),
+	FOREIGN KEY("Metric_id") REFERENCES "Metric" (id),
+	FOREIGN KEY("hasPart_id") REFERENCES "Concept" (id)
+);
+CREATE INDEX "ix_Metric_hasPart_Metric_id" ON "Metric_hasPart" ("Metric_id");
+CREATE INDEX "ix_Metric_hasPart_hasPart_id" ON "Metric_hasPart" ("hasPart_id");
+
+CREATE TABLE "Metric_references" (
+	"Metric_id" TEXT,
+	references_id TEXT,
+	PRIMARY KEY ("Metric_id", references_id),
+	FOREIGN KEY("Metric_id") REFERENCES "Metric" (id),
+	FOREIGN KEY(references_id) REFERENCES "Concept" (id)
+);
+CREATE INDEX "ix_Metric_references_references_id" ON "Metric_references" (references_id);
+CREATE INDEX "ix_Metric_references_Metric_id" ON "Metric_references" ("Metric_id");
+
+CREATE TABLE "Metric_dependsOn" (
+	"Metric_id" TEXT,
+	"dependsOn_id" TEXT,
+	PRIMARY KEY ("Metric_id", "dependsOn_id"),
+	FOREIGN KEY("Metric_id") REFERENCES "Metric" (id),
+	FOREIGN KEY("dependsOn_id") REFERENCES "Concept" (id)
+);
+CREATE INDEX "ix_Metric_dependsOn_dependsOn_id" ON "Metric_dependsOn" ("dependsOn_id");
+CREATE INDEX "ix_Metric_dependsOn_Metric_id" ON "Metric_dependsOn" ("Metric_id");
+
+CREATE TABLE "Metric_derivedFrom" (
+	"Metric_id" TEXT,
+	"derivedFrom_id" TEXT,
+	PRIMARY KEY ("Metric_id", "derivedFrom_id"),
+	FOREIGN KEY("Metric_id") REFERENCES "Metric" (id),
+	FOREIGN KEY("derivedFrom_id") REFERENCES "Concept" (id)
+);
+CREATE INDEX "ix_Metric_derivedFrom_Metric_id" ON "Metric_derivedFrom" ("Metric_id");
+CREATE INDEX "ix_Metric_derivedFrom_derivedFrom_id" ON "Metric_derivedFrom" ("derivedFrom_id");
+
+CREATE TABLE "Metric_about" (
+	"Metric_id" TEXT,
+	about_id TEXT,
+	PRIMARY KEY ("Metric_id", about_id),
+	FOREIGN KEY("Metric_id") REFERENCES "Metric" (id),
+	FOREIGN KEY(about_id) REFERENCES "Concept" (id)
+);
+CREATE INDEX "ix_Metric_about_Metric_id" ON "Metric_about" ("Metric_id");
+CREATE INDEX "ix_Metric_about_about_id" ON "Metric_about" (about_id);
+
+CREATE TABLE "Metric_sameAs" (
+	"Metric_id" TEXT,
+	"sameAs_id" TEXT,
+	PRIMARY KEY ("Metric_id", "sameAs_id"),
+	FOREIGN KEY("Metric_id") REFERENCES "Metric" (id),
+	FOREIGN KEY("sameAs_id") REFERENCES "Concept" (id)
+);
+CREATE INDEX "ix_Metric_sameAs_sameAs_id" ON "Metric_sameAs" ("sameAs_id");
+CREATE INDEX "ix_Metric_sameAs_Metric_id" ON "Metric_sameAs" ("Metric_id");
+
+CREATE TABLE "Metric_relatedTo" (
+	"Metric_id" TEXT,
+	"relatedTo_id" TEXT,
+	PRIMARY KEY ("Metric_id", "relatedTo_id"),
+	FOREIGN KEY("Metric_id") REFERENCES "Metric" (id),
+	FOREIGN KEY("relatedTo_id") REFERENCES "Concept" (id)
+);
+CREATE INDEX "ix_Metric_relatedTo_relatedTo_id" ON "Metric_relatedTo" ("relatedTo_id");
+CREATE INDEX "ix_Metric_relatedTo_Metric_id" ON "Metric_relatedTo" ("Metric_id");
+
+CREATE TABLE "Metric_definedBy" (
+	"Metric_id" TEXT,
+	"definedBy_id" TEXT,
+	PRIMARY KEY ("Metric_id", "definedBy_id"),
+	FOREIGN KEY("Metric_id") REFERENCES "Metric" (id),
+	FOREIGN KEY("definedBy_id") REFERENCES "Concept" (id)
+);
+CREATE INDEX "ix_Metric_definedBy_definedBy_id" ON "Metric_definedBy" ("definedBy_id");
+CREATE INDEX "ix_Metric_definedBy_Metric_id" ON "Metric_definedBy" ("Metric_id");
+
+CREATE TABLE "Metric_source" (
+	"Metric_id" TEXT,
+	source_id TEXT,
+	PRIMARY KEY ("Metric_id", source_id),
+	FOREIGN KEY("Metric_id") REFERENCES "Metric" (id),
+	FOREIGN KEY(source_id) REFERENCES "Concept" (id)
+);
+CREATE INDEX "ix_Metric_source_Metric_id" ON "Metric_source" ("Metric_id");
+CREATE INDEX "ix_Metric_source_source_id" ON "Metric_source" (source_id);
+
+CREATE TABLE "Service_tags" (
+	"Service_id" TEXT,
+	tags TEXT,
+	PRIMARY KEY ("Service_id", tags),
+	FOREIGN KEY("Service_id") REFERENCES "Service" (id)
+);
+CREATE INDEX "ix_Service_tags_tags" ON "Service_tags" (tags);
+CREATE INDEX "ix_Service_tags_Service_id" ON "Service_tags" ("Service_id");
+
+CREATE TABLE "Service_isPartOf" (
+	"Service_id" TEXT,
+	"isPartOf_id" TEXT,
+	PRIMARY KEY ("Service_id", "isPartOf_id"),
+	FOREIGN KEY("Service_id") REFERENCES "Service" (id),
+	FOREIGN KEY("isPartOf_id") REFERENCES "Concept" (id)
+);
+CREATE INDEX "ix_Service_isPartOf_Service_id" ON "Service_isPartOf" ("Service_id");
+CREATE INDEX "ix_Service_isPartOf_isPartOf_id" ON "Service_isPartOf" ("isPartOf_id");
+
+CREATE TABLE "Service_hasPart" (
+	"Service_id" TEXT,
+	"hasPart_id" TEXT,
+	PRIMARY KEY ("Service_id", "hasPart_id"),
+	FOREIGN KEY("Service_id") REFERENCES "Service" (id),
+	FOREIGN KEY("hasPart_id") REFERENCES "Concept" (id)
+);
+CREATE INDEX "ix_Service_hasPart_hasPart_id" ON "Service_hasPart" ("hasPart_id");
+CREATE INDEX "ix_Service_hasPart_Service_id" ON "Service_hasPart" ("Service_id");
+
+CREATE TABLE "Service_references" (
+	"Service_id" TEXT,
+	references_id TEXT,
+	PRIMARY KEY ("Service_id", references_id),
+	FOREIGN KEY("Service_id") REFERENCES "Service" (id),
+	FOREIGN KEY(references_id) REFERENCES "Concept" (id)
+);
+CREATE INDEX "ix_Service_references_references_id" ON "Service_references" (references_id);
+CREATE INDEX "ix_Service_references_Service_id" ON "Service_references" ("Service_id");
+
+CREATE TABLE "Service_dependsOn" (
+	"Service_id" TEXT,
+	"dependsOn_id" TEXT,
+	PRIMARY KEY ("Service_id", "dependsOn_id"),
+	FOREIGN KEY("Service_id") REFERENCES "Service" (id),
+	FOREIGN KEY("dependsOn_id") REFERENCES "Concept" (id)
+);
+CREATE INDEX "ix_Service_dependsOn_Service_id" ON "Service_dependsOn" ("Service_id");
+CREATE INDEX "ix_Service_dependsOn_dependsOn_id" ON "Service_dependsOn" ("dependsOn_id");
+
+CREATE TABLE "Service_derivedFrom" (
+	"Service_id" TEXT,
+	"derivedFrom_id" TEXT,
+	PRIMARY KEY ("Service_id", "derivedFrom_id"),
+	FOREIGN KEY("Service_id") REFERENCES "Service" (id),
+	FOREIGN KEY("derivedFrom_id") REFERENCES "Concept" (id)
+);
+CREATE INDEX "ix_Service_derivedFrom_derivedFrom_id" ON "Service_derivedFrom" ("derivedFrom_id");
+CREATE INDEX "ix_Service_derivedFrom_Service_id" ON "Service_derivedFrom" ("Service_id");
+
+CREATE TABLE "Service_about" (
+	"Service_id" TEXT,
+	about_id TEXT,
+	PRIMARY KEY ("Service_id", about_id),
+	FOREIGN KEY("Service_id") REFERENCES "Service" (id),
+	FOREIGN KEY(about_id) REFERENCES "Concept" (id)
+);
+CREATE INDEX "ix_Service_about_Service_id" ON "Service_about" ("Service_id");
+CREATE INDEX "ix_Service_about_about_id" ON "Service_about" (about_id);
+
+CREATE TABLE "Service_sameAs" (
+	"Service_id" TEXT,
+	"sameAs_id" TEXT,
+	PRIMARY KEY ("Service_id", "sameAs_id"),
+	FOREIGN KEY("Service_id") REFERENCES "Service" (id),
+	FOREIGN KEY("sameAs_id") REFERENCES "Concept" (id)
+);
+CREATE INDEX "ix_Service_sameAs_Service_id" ON "Service_sameAs" ("Service_id");
+CREATE INDEX "ix_Service_sameAs_sameAs_id" ON "Service_sameAs" ("sameAs_id");
+
+CREATE TABLE "Service_relatedTo" (
+	"Service_id" TEXT,
+	"relatedTo_id" TEXT,
+	PRIMARY KEY ("Service_id", "relatedTo_id"),
+	FOREIGN KEY("Service_id") REFERENCES "Service" (id),
+	FOREIGN KEY("relatedTo_id") REFERENCES "Concept" (id)
+);
+CREATE INDEX "ix_Service_relatedTo_Service_id" ON "Service_relatedTo" ("Service_id");
+CREATE INDEX "ix_Service_relatedTo_relatedTo_id" ON "Service_relatedTo" ("relatedTo_id");
+
+CREATE TABLE "Service_definedBy" (
+	"Service_id" TEXT,
+	"definedBy_id" TEXT,
+	PRIMARY KEY ("Service_id", "definedBy_id"),
+	FOREIGN KEY("Service_id") REFERENCES "Service" (id),
+	FOREIGN KEY("definedBy_id") REFERENCES "Concept" (id)
+);
+CREATE INDEX "ix_Service_definedBy_definedBy_id" ON "Service_definedBy" ("definedBy_id");
+CREATE INDEX "ix_Service_definedBy_Service_id" ON "Service_definedBy" ("Service_id");
+
+CREATE TABLE "Service_source" (
+	"Service_id" TEXT,
+	source_id TEXT,
+	PRIMARY KEY ("Service_id", source_id),
+	FOREIGN KEY("Service_id") REFERENCES "Service" (id),
+	FOREIGN KEY(source_id) REFERENCES "Concept" (id)
+);
+CREATE INDEX "ix_Service_source_Service_id" ON "Service_source" ("Service_id");
+CREATE INDEX "ix_Service_source_source_id" ON "Service_source" (source_id);
+
+CREATE TABLE "Playbook_tags" (
+	"Playbook_id" TEXT,
+	tags TEXT,
+	PRIMARY KEY ("Playbook_id", tags),
+	FOREIGN KEY("Playbook_id") REFERENCES "Playbook" (id)
+);
+CREATE INDEX "ix_Playbook_tags_tags" ON "Playbook_tags" (tags);
+CREATE INDEX "ix_Playbook_tags_Playbook_id" ON "Playbook_tags" ("Playbook_id");
+
+CREATE TABLE "Playbook_isPartOf" (
+	"Playbook_id" TEXT,
+	"isPartOf_id" TEXT,
+	PRIMARY KEY ("Playbook_id", "isPartOf_id"),
+	FOREIGN KEY("Playbook_id") REFERENCES "Playbook" (id),
+	FOREIGN KEY("isPartOf_id") REFERENCES "Concept" (id)
+);
+CREATE INDEX "ix_Playbook_isPartOf_Playbook_id" ON "Playbook_isPartOf" ("Playbook_id");
+CREATE INDEX "ix_Playbook_isPartOf_isPartOf_id" ON "Playbook_isPartOf" ("isPartOf_id");
+
+CREATE TABLE "Playbook_hasPart" (
+	"Playbook_id" TEXT,
+	"hasPart_id" TEXT,
+	PRIMARY KEY ("Playbook_id", "hasPart_id"),
+	FOREIGN KEY("Playbook_id") REFERENCES "Playbook" (id),
+	FOREIGN KEY("hasPart_id") REFERENCES "Concept" (id)
+);
+CREATE INDEX "ix_Playbook_hasPart_hasPart_id" ON "Playbook_hasPart" ("hasPart_id");
+CREATE INDEX "ix_Playbook_hasPart_Playbook_id" ON "Playbook_hasPart" ("Playbook_id");
+
+CREATE TABLE "Playbook_references" (
+	"Playbook_id" TEXT,
+	references_id TEXT,
+	PRIMARY KEY ("Playbook_id", references_id),
+	FOREIGN KEY("Playbook_id") REFERENCES "Playbook" (id),
+	FOREIGN KEY(references_id) REFERENCES "Concept" (id)
+);
+CREATE INDEX "ix_Playbook_references_Playbook_id" ON "Playbook_references" ("Playbook_id");
+CREATE INDEX "ix_Playbook_references_references_id" ON "Playbook_references" (references_id);
+
+CREATE TABLE "Playbook_dependsOn" (
+	"Playbook_id" TEXT,
+	"dependsOn_id" TEXT,
+	PRIMARY KEY ("Playbook_id", "dependsOn_id"),
+	FOREIGN KEY("Playbook_id") REFERENCES "Playbook" (id),
+	FOREIGN KEY("dependsOn_id") REFERENCES "Concept" (id)
+);
+CREATE INDEX "ix_Playbook_dependsOn_Playbook_id" ON "Playbook_dependsOn" ("Playbook_id");
+CREATE INDEX "ix_Playbook_dependsOn_dependsOn_id" ON "Playbook_dependsOn" ("dependsOn_id");
+
+CREATE TABLE "Playbook_derivedFrom" (
+	"Playbook_id" TEXT,
+	"derivedFrom_id" TEXT,
+	PRIMARY KEY ("Playbook_id", "derivedFrom_id"),
+	FOREIGN KEY("Playbook_id") REFERENCES "Playbook" (id),
+	FOREIGN KEY("derivedFrom_id") REFERENCES "Concept" (id)
+);
+CREATE INDEX "ix_Playbook_derivedFrom_derivedFrom_id" ON "Playbook_derivedFrom" ("derivedFrom_id");
+CREATE INDEX "ix_Playbook_derivedFrom_Playbook_id" ON "Playbook_derivedFrom" ("Playbook_id");
+
+CREATE TABLE "Playbook_about" (
+	"Playbook_id" TEXT,
+	about_id TEXT,
+	PRIMARY KEY ("Playbook_id", about_id),
+	FOREIGN KEY("Playbook_id") REFERENCES "Playbook" (id),
+	FOREIGN KEY(about_id) REFERENCES "Concept" (id)
+);
+CREATE INDEX "ix_Playbook_about_Playbook_id" ON "Playbook_about" ("Playbook_id");
+CREATE INDEX "ix_Playbook_about_about_id" ON "Playbook_about" (about_id);
+
+CREATE TABLE "Playbook_sameAs" (
+	"Playbook_id" TEXT,
+	"sameAs_id" TEXT,
+	PRIMARY KEY ("Playbook_id", "sameAs_id"),
+	FOREIGN KEY("Playbook_id") REFERENCES "Playbook" (id),
+	FOREIGN KEY("sameAs_id") REFERENCES "Concept" (id)
+);
+CREATE INDEX "ix_Playbook_sameAs_sameAs_id" ON "Playbook_sameAs" ("sameAs_id");
+CREATE INDEX "ix_Playbook_sameAs_Playbook_id" ON "Playbook_sameAs" ("Playbook_id");
+
+CREATE TABLE "Playbook_relatedTo" (
+	"Playbook_id" TEXT,
+	"relatedTo_id" TEXT,
+	PRIMARY KEY ("Playbook_id", "relatedTo_id"),
+	FOREIGN KEY("Playbook_id") REFERENCES "Playbook" (id),
+	FOREIGN KEY("relatedTo_id") REFERENCES "Concept" (id)
+);
+CREATE INDEX "ix_Playbook_relatedTo_Playbook_id" ON "Playbook_relatedTo" ("Playbook_id");
+CREATE INDEX "ix_Playbook_relatedTo_relatedTo_id" ON "Playbook_relatedTo" ("relatedTo_id");
+
+CREATE TABLE "Playbook_definedBy" (
+	"Playbook_id" TEXT,
+	"definedBy_id" TEXT,
+	PRIMARY KEY ("Playbook_id", "definedBy_id"),
+	FOREIGN KEY("Playbook_id") REFERENCES "Playbook" (id),
+	FOREIGN KEY("definedBy_id") REFERENCES "Concept" (id)
+);
+CREATE INDEX "ix_Playbook_definedBy_Playbook_id" ON "Playbook_definedBy" ("Playbook_id");
+CREATE INDEX "ix_Playbook_definedBy_definedBy_id" ON "Playbook_definedBy" ("definedBy_id");
+
+CREATE TABLE "Playbook_source" (
+	"Playbook_id" TEXT,
+	source_id TEXT,
+	PRIMARY KEY ("Playbook_id", source_id),
+	FOREIGN KEY("Playbook_id") REFERENCES "Playbook" (id),
+	FOREIGN KEY(source_id) REFERENCES "Concept" (id)
+);
+CREATE INDEX "ix_Playbook_source_Playbook_id" ON "Playbook_source" ("Playbook_id");
+CREATE INDEX "ix_Playbook_source_source_id" ON "Playbook_source" (source_id);
+
+CREATE TABLE "Policy_tags" (
+	"Policy_id" TEXT,
+	tags TEXT,
+	PRIMARY KEY ("Policy_id", tags),
+	FOREIGN KEY("Policy_id") REFERENCES "Policy" (id)
+);
+CREATE INDEX "ix_Policy_tags_Policy_id" ON "Policy_tags" ("Policy_id");
+CREATE INDEX "ix_Policy_tags_tags" ON "Policy_tags" (tags);
+
+CREATE TABLE "Policy_isPartOf" (
+	"Policy_id" TEXT,
+	"isPartOf_id" TEXT,
+	PRIMARY KEY ("Policy_id", "isPartOf_id"),
+	FOREIGN KEY("Policy_id") REFERENCES "Policy" (id),
+	FOREIGN KEY("isPartOf_id") REFERENCES "Concept" (id)
+);
+CREATE INDEX "ix_Policy_isPartOf_Policy_id" ON "Policy_isPartOf" ("Policy_id");
+CREATE INDEX "ix_Policy_isPartOf_isPartOf_id" ON "Policy_isPartOf" ("isPartOf_id");
+
+CREATE TABLE "Policy_hasPart" (
+	"Policy_id" TEXT,
+	"hasPart_id" TEXT,
+	PRIMARY KEY ("Policy_id", "hasPart_id"),
+	FOREIGN KEY("Policy_id") REFERENCES "Policy" (id),
+	FOREIGN KEY("hasPart_id") REFERENCES "Concept" (id)
+);
+CREATE INDEX "ix_Policy_hasPart_hasPart_id" ON "Policy_hasPart" ("hasPart_id");
+CREATE INDEX "ix_Policy_hasPart_Policy_id" ON "Policy_hasPart" ("Policy_id");
+
+CREATE TABLE "Policy_references" (
+	"Policy_id" TEXT,
+	references_id TEXT,
+	PRIMARY KEY ("Policy_id", references_id),
+	FOREIGN KEY("Policy_id") REFERENCES "Policy" (id),
+	FOREIGN KEY(references_id) REFERENCES "Concept" (id)
+);
+CREATE INDEX "ix_Policy_references_references_id" ON "Policy_references" (references_id);
+CREATE INDEX "ix_Policy_references_Policy_id" ON "Policy_references" ("Policy_id");
+
+CREATE TABLE "Policy_dependsOn" (
+	"Policy_id" TEXT,
+	"dependsOn_id" TEXT,
+	PRIMARY KEY ("Policy_id", "dependsOn_id"),
+	FOREIGN KEY("Policy_id") REFERENCES "Policy" (id),
+	FOREIGN KEY("dependsOn_id") REFERENCES "Concept" (id)
+);
+CREATE INDEX "ix_Policy_dependsOn_Policy_id" ON "Policy_dependsOn" ("Policy_id");
+CREATE INDEX "ix_Policy_dependsOn_dependsOn_id" ON "Policy_dependsOn" ("dependsOn_id");
+
+CREATE TABLE "Policy_derivedFrom" (
+	"Policy_id" TEXT,
+	"derivedFrom_id" TEXT,
+	PRIMARY KEY ("Policy_id", "derivedFrom_id"),
+	FOREIGN KEY("Policy_id") REFERENCES "Policy" (id),
+	FOREIGN KEY("derivedFrom_id") REFERENCES "Concept" (id)
+);
+CREATE INDEX "ix_Policy_derivedFrom_derivedFrom_id" ON "Policy_derivedFrom" ("derivedFrom_id");
+CREATE INDEX "ix_Policy_derivedFrom_Policy_id" ON "Policy_derivedFrom" ("Policy_id");
+
+CREATE TABLE "Policy_about" (
+	"Policy_id" TEXT,
+	about_id TEXT,
+	PRIMARY KEY ("Policy_id", about_id),
+	FOREIGN KEY("Policy_id") REFERENCES "Policy" (id),
+	FOREIGN KEY(about_id) REFERENCES "Concept" (id)
+);
+CREATE INDEX "ix_Policy_about_Policy_id" ON "Policy_about" ("Policy_id");
+CREATE INDEX "ix_Policy_about_about_id" ON "Policy_about" (about_id);
+
+CREATE TABLE "Policy_sameAs" (
+	"Policy_id" TEXT,
+	"sameAs_id" TEXT,
+	PRIMARY KEY ("Policy_id", "sameAs_id"),
+	FOREIGN KEY("Policy_id") REFERENCES "Policy" (id),
+	FOREIGN KEY("sameAs_id") REFERENCES "Concept" (id)
+);
+CREATE INDEX "ix_Policy_sameAs_sameAs_id" ON "Policy_sameAs" ("sameAs_id");
+CREATE INDEX "ix_Policy_sameAs_Policy_id" ON "Policy_sameAs" ("Policy_id");
+
+CREATE TABLE "Policy_relatedTo" (
+	"Policy_id" TEXT,
+	"relatedTo_id" TEXT,
+	PRIMARY KEY ("Policy_id", "relatedTo_id"),
+	FOREIGN KEY("Policy_id") REFERENCES "Policy" (id),
+	FOREIGN KEY("relatedTo_id") REFERENCES "Concept" (id)
+);
+CREATE INDEX "ix_Policy_relatedTo_relatedTo_id" ON "Policy_relatedTo" ("relatedTo_id");
+CREATE INDEX "ix_Policy_relatedTo_Policy_id" ON "Policy_relatedTo" ("Policy_id");
+
+CREATE TABLE "Policy_definedBy" (
+	"Policy_id" TEXT,
+	"definedBy_id" TEXT,
+	PRIMARY KEY ("Policy_id", "definedBy_id"),
+	FOREIGN KEY("Policy_id") REFERENCES "Policy" (id),
+	FOREIGN KEY("definedBy_id") REFERENCES "Concept" (id)
+);
+CREATE INDEX "ix_Policy_definedBy_Policy_id" ON "Policy_definedBy" ("Policy_id");
+CREATE INDEX "ix_Policy_definedBy_definedBy_id" ON "Policy_definedBy" ("definedBy_id");
+
+CREATE TABLE "Policy_source" (
+	"Policy_id" TEXT,
+	source_id TEXT,
+	PRIMARY KEY ("Policy_id", source_id),
+	FOREIGN KEY("Policy_id") REFERENCES "Policy" (id),
+	FOREIGN KEY(source_id) REFERENCES "Concept" (id)
+);
+CREATE INDEX "ix_Policy_source_source_id" ON "Policy_source" (source_id);
+CREATE INDEX "ix_Policy_source_Policy_id" ON "Policy_source" ("Policy_id");
+
+CREATE TABLE "GlossaryTerm_tags" (
+	"GlossaryTerm_id" TEXT,
+	tags TEXT,
+	PRIMARY KEY ("GlossaryTerm_id", tags),
+	FOREIGN KEY("GlossaryTerm_id") REFERENCES "GlossaryTerm" (id)
+);
+CREATE INDEX "ix_GlossaryTerm_tags_GlossaryTerm_id" ON "GlossaryTerm_tags" ("GlossaryTerm_id");
+CREATE INDEX "ix_GlossaryTerm_tags_tags" ON "GlossaryTerm_tags" (tags);
+
+CREATE TABLE "GlossaryTerm_isPartOf" (
+	"GlossaryTerm_id" TEXT,
+	"isPartOf_id" TEXT,
+	PRIMARY KEY ("GlossaryTerm_id", "isPartOf_id"),
+	FOREIGN KEY("GlossaryTerm_id") REFERENCES "GlossaryTerm" (id),
+	FOREIGN KEY("isPartOf_id") REFERENCES "Concept" (id)
+);
+CREATE INDEX "ix_GlossaryTerm_isPartOf_isPartOf_id" ON "GlossaryTerm_isPartOf" ("isPartOf_id");
+CREATE INDEX "ix_GlossaryTerm_isPartOf_GlossaryTerm_id" ON "GlossaryTerm_isPartOf" ("GlossaryTerm_id");
+
+CREATE TABLE "GlossaryTerm_hasPart" (
+	"GlossaryTerm_id" TEXT,
+	"hasPart_id" TEXT,
+	PRIMARY KEY ("GlossaryTerm_id", "hasPart_id"),
+	FOREIGN KEY("GlossaryTerm_id") REFERENCES "GlossaryTerm" (id),
+	FOREIGN KEY("hasPart_id") REFERENCES "Concept" (id)
+);
+CREATE INDEX "ix_GlossaryTerm_hasPart_hasPart_id" ON "GlossaryTerm_hasPart" ("hasPart_id");
+CREATE INDEX "ix_GlossaryTerm_hasPart_GlossaryTerm_id" ON "GlossaryTerm_hasPart" ("GlossaryTerm_id");
+
+CREATE TABLE "GlossaryTerm_references" (
+	"GlossaryTerm_id" TEXT,
+	references_id TEXT,
+	PRIMARY KEY ("GlossaryTerm_id", references_id),
+	FOREIGN KEY("GlossaryTerm_id") REFERENCES "GlossaryTerm" (id),
+	FOREIGN KEY(references_id) REFERENCES "Concept" (id)
+);
+CREATE INDEX "ix_GlossaryTerm_references_references_id" ON "GlossaryTerm_references" (references_id);
+CREATE INDEX "ix_GlossaryTerm_references_GlossaryTerm_id" ON "GlossaryTerm_references" ("GlossaryTerm_id");
+
+CREATE TABLE "GlossaryTerm_dependsOn" (
+	"GlossaryTerm_id" TEXT,
+	"dependsOn_id" TEXT,
+	PRIMARY KEY ("GlossaryTerm_id", "dependsOn_id"),
+	FOREIGN KEY("GlossaryTerm_id") REFERENCES "GlossaryTerm" (id),
+	FOREIGN KEY("dependsOn_id") REFERENCES "Concept" (id)
+);
+CREATE INDEX "ix_GlossaryTerm_dependsOn_GlossaryTerm_id" ON "GlossaryTerm_dependsOn" ("GlossaryTerm_id");
+CREATE INDEX "ix_GlossaryTerm_dependsOn_dependsOn_id" ON "GlossaryTerm_dependsOn" ("dependsOn_id");
+
+CREATE TABLE "GlossaryTerm_derivedFrom" (
+	"GlossaryTerm_id" TEXT,
+	"derivedFrom_id" TEXT,
+	PRIMARY KEY ("GlossaryTerm_id", "derivedFrom_id"),
+	FOREIGN KEY("GlossaryTerm_id") REFERENCES "GlossaryTerm" (id),
+	FOREIGN KEY("derivedFrom_id") REFERENCES "Concept" (id)
+);
+CREATE INDEX "ix_GlossaryTerm_derivedFrom_GlossaryTerm_id" ON "GlossaryTerm_derivedFrom" ("GlossaryTerm_id");
+CREATE INDEX "ix_GlossaryTerm_derivedFrom_derivedFrom_id" ON "GlossaryTerm_derivedFrom" ("derivedFrom_id");
+
+CREATE TABLE "GlossaryTerm_about" (
+	"GlossaryTerm_id" TEXT,
+	about_id TEXT,
+	PRIMARY KEY ("GlossaryTerm_id", about_id),
+	FOREIGN KEY("GlossaryTerm_id") REFERENCES "GlossaryTerm" (id),
+	FOREIGN KEY(about_id) REFERENCES "Concept" (id)
+);
+CREATE INDEX "ix_GlossaryTerm_about_about_id" ON "GlossaryTerm_about" (about_id);
+CREATE INDEX "ix_GlossaryTerm_about_GlossaryTerm_id" ON "GlossaryTerm_about" ("GlossaryTerm_id");
+
+CREATE TABLE "GlossaryTerm_sameAs" (
+	"GlossaryTerm_id" TEXT,
+	"sameAs_id" TEXT,
+	PRIMARY KEY ("GlossaryTerm_id", "sameAs_id"),
+	FOREIGN KEY("GlossaryTerm_id") REFERENCES "GlossaryTerm" (id),
+	FOREIGN KEY("sameAs_id") REFERENCES "Concept" (id)
+);
+CREATE INDEX "ix_GlossaryTerm_sameAs_GlossaryTerm_id" ON "GlossaryTerm_sameAs" ("GlossaryTerm_id");
+CREATE INDEX "ix_GlossaryTerm_sameAs_sameAs_id" ON "GlossaryTerm_sameAs" ("sameAs_id");
+
+CREATE TABLE "GlossaryTerm_relatedTo" (
+	"GlossaryTerm_id" TEXT,
+	"relatedTo_id" TEXT,
+	PRIMARY KEY ("GlossaryTerm_id", "relatedTo_id"),
+	FOREIGN KEY("GlossaryTerm_id") REFERENCES "GlossaryTerm" (id),
+	FOREIGN KEY("relatedTo_id") REFERENCES "Concept" (id)
+);
+CREATE INDEX "ix_GlossaryTerm_relatedTo_relatedTo_id" ON "GlossaryTerm_relatedTo" ("relatedTo_id");
+CREATE INDEX "ix_GlossaryTerm_relatedTo_GlossaryTerm_id" ON "GlossaryTerm_relatedTo" ("GlossaryTerm_id");
+
+CREATE TABLE "GlossaryTerm_definedBy" (
+	"GlossaryTerm_id" TEXT,
+	"definedBy_id" TEXT,
+	PRIMARY KEY ("GlossaryTerm_id", "definedBy_id"),
+	FOREIGN KEY("GlossaryTerm_id") REFERENCES "GlossaryTerm" (id),
+	FOREIGN KEY("definedBy_id") REFERENCES "Concept" (id)
+);
+CREATE INDEX "ix_GlossaryTerm_definedBy_definedBy_id" ON "GlossaryTerm_definedBy" ("definedBy_id");
+CREATE INDEX "ix_GlossaryTerm_definedBy_GlossaryTerm_id" ON "GlossaryTerm_definedBy" ("GlossaryTerm_id");
+
+CREATE TABLE "GlossaryTerm_source" (
+	"GlossaryTerm_id" TEXT,
+	source_id TEXT,
+	PRIMARY KEY ("GlossaryTerm_id", source_id),
+	FOREIGN KEY("GlossaryTerm_id") REFERENCES "GlossaryTerm" (id),
+	FOREIGN KEY(source_id) REFERENCES "Concept" (id)
+);
+CREATE INDEX "ix_GlossaryTerm_source_GlossaryTerm_id" ON "GlossaryTerm_source" ("GlossaryTerm_id");
+CREATE INDEX "ix_GlossaryTerm_source_source_id" ON "GlossaryTerm_source" (source_id);
+
+CREATE TABLE "Reference_tags" (
+	"Reference_id" TEXT,
+	tags TEXT,
+	PRIMARY KEY ("Reference_id", tags),
+	FOREIGN KEY("Reference_id") REFERENCES "Reference" (id)
+);
+CREATE INDEX "ix_Reference_tags_tags" ON "Reference_tags" (tags);
+CREATE INDEX "ix_Reference_tags_Reference_id" ON "Reference_tags" ("Reference_id");
+
+CREATE TABLE "Reference_isPartOf" (
+	"Reference_id" TEXT,
+	"isPartOf_id" TEXT,
+	PRIMARY KEY ("Reference_id", "isPartOf_id"),
+	FOREIGN KEY("Reference_id") REFERENCES "Reference" (id),
+	FOREIGN KEY("isPartOf_id") REFERENCES "Concept" (id)
+);
+CREATE INDEX "ix_Reference_isPartOf_isPartOf_id" ON "Reference_isPartOf" ("isPartOf_id");
+CREATE INDEX "ix_Reference_isPartOf_Reference_id" ON "Reference_isPartOf" ("Reference_id");
+
+CREATE TABLE "Reference_hasPart" (
+	"Reference_id" TEXT,
+	"hasPart_id" TEXT,
+	PRIMARY KEY ("Reference_id", "hasPart_id"),
+	FOREIGN KEY("Reference_id") REFERENCES "Reference" (id),
+	FOREIGN KEY("hasPart_id") REFERENCES "Concept" (id)
+);
+CREATE INDEX "ix_Reference_hasPart_hasPart_id" ON "Reference_hasPart" ("hasPart_id");
+CREATE INDEX "ix_Reference_hasPart_Reference_id" ON "Reference_hasPart" ("Reference_id");
+
+CREATE TABLE "Reference_references" (
+	"Reference_id" TEXT,
+	references_id TEXT,
+	PRIMARY KEY ("Reference_id", references_id),
+	FOREIGN KEY("Reference_id") REFERENCES "Reference" (id),
+	FOREIGN KEY(references_id) REFERENCES "Concept" (id)
+);
+CREATE INDEX "ix_Reference_references_references_id" ON "Reference_references" (references_id);
+CREATE INDEX "ix_Reference_references_Reference_id" ON "Reference_references" ("Reference_id");
+
+CREATE TABLE "Reference_dependsOn" (
+	"Reference_id" TEXT,
+	"dependsOn_id" TEXT,
+	PRIMARY KEY ("Reference_id", "dependsOn_id"),
+	FOREIGN KEY("Reference_id") REFERENCES "Reference" (id),
+	FOREIGN KEY("dependsOn_id") REFERENCES "Concept" (id)
+);
+CREATE INDEX "ix_Reference_dependsOn_dependsOn_id" ON "Reference_dependsOn" ("dependsOn_id");
+CREATE INDEX "ix_Reference_dependsOn_Reference_id" ON "Reference_dependsOn" ("Reference_id");
+
+CREATE TABLE "Reference_derivedFrom" (
+	"Reference_id" TEXT,
+	"derivedFrom_id" TEXT,
+	PRIMARY KEY ("Reference_id", "derivedFrom_id"),
+	FOREIGN KEY("Reference_id") REFERENCES "Reference" (id),
+	FOREIGN KEY("derivedFrom_id") REFERENCES "Concept" (id)
+);
+CREATE INDEX "ix_Reference_derivedFrom_Reference_id" ON "Reference_derivedFrom" ("Reference_id");
+CREATE INDEX "ix_Reference_derivedFrom_derivedFrom_id" ON "Reference_derivedFrom" ("derivedFrom_id");
+
+CREATE TABLE "Reference_about" (
+	"Reference_id" TEXT,
+	about_id TEXT,
+	PRIMARY KEY ("Reference_id", about_id),
+	FOREIGN KEY("Reference_id") REFERENCES "Reference" (id),
+	FOREIGN KEY(about_id) REFERENCES "Concept" (id)
+);
+CREATE INDEX "ix_Reference_about_about_id" ON "Reference_about" (about_id);
+CREATE INDEX "ix_Reference_about_Reference_id" ON "Reference_about" ("Reference_id");
+
+CREATE TABLE "Reference_sameAs" (
+	"Reference_id" TEXT,
+	"sameAs_id" TEXT,
+	PRIMARY KEY ("Reference_id", "sameAs_id"),
+	FOREIGN KEY("Reference_id") REFERENCES "Reference" (id),
+	FOREIGN KEY("sameAs_id") REFERENCES "Concept" (id)
+);
+CREATE INDEX "ix_Reference_sameAs_sameAs_id" ON "Reference_sameAs" ("sameAs_id");
+CREATE INDEX "ix_Reference_sameAs_Reference_id" ON "Reference_sameAs" ("Reference_id");
+
+CREATE TABLE "Reference_relatedTo" (
+	"Reference_id" TEXT,
+	"relatedTo_id" TEXT,
+	PRIMARY KEY ("Reference_id", "relatedTo_id"),
+	FOREIGN KEY("Reference_id") REFERENCES "Reference" (id),
+	FOREIGN KEY("relatedTo_id") REFERENCES "Concept" (id)
+);
+CREATE INDEX "ix_Reference_relatedTo_relatedTo_id" ON "Reference_relatedTo" ("relatedTo_id");
+CREATE INDEX "ix_Reference_relatedTo_Reference_id" ON "Reference_relatedTo" ("Reference_id");
+
+CREATE TABLE "Reference_definedBy" (
+	"Reference_id" TEXT,
+	"definedBy_id" TEXT,
+	PRIMARY KEY ("Reference_id", "definedBy_id"),
+	FOREIGN KEY("Reference_id") REFERENCES "Reference" (id),
+	FOREIGN KEY("definedBy_id") REFERENCES "Concept" (id)
+);
+CREATE INDEX "ix_Reference_definedBy_Reference_id" ON "Reference_definedBy" ("Reference_id");
+CREATE INDEX "ix_Reference_definedBy_definedBy_id" ON "Reference_definedBy" ("definedBy_id");
+
+CREATE TABLE "Reference_source" (
+	"Reference_id" TEXT,
+	source_id TEXT,
+	PRIMARY KEY ("Reference_id", source_id),
+	FOREIGN KEY("Reference_id") REFERENCES "Reference" (id),
+	FOREIGN KEY(source_id) REFERENCES "Concept" (id)
+);
+CREATE INDEX "ix_Reference_source_source_id" ON "Reference_source" (source_id);
+CREATE INDEX "ix_Reference_source_Reference_id" ON "Reference_source" ("Reference_id");
+
+CREATE TABLE "Document_tags" (
+	"Document_id" TEXT,
+	tags TEXT,
+	PRIMARY KEY ("Document_id", tags),
+	FOREIGN KEY("Document_id") REFERENCES "Document" (id)
+);
+CREATE INDEX "ix_Document_tags_tags" ON "Document_tags" (tags);
+CREATE INDEX "ix_Document_tags_Document_id" ON "Document_tags" ("Document_id");
+
+CREATE TABLE "Document_isPartOf" (
+	"Document_id" TEXT,
+	"isPartOf_id" TEXT,
+	PRIMARY KEY ("Document_id", "isPartOf_id"),
+	FOREIGN KEY("Document_id") REFERENCES "Document" (id),
+	FOREIGN KEY("isPartOf_id") REFERENCES "Concept" (id)
+);
+CREATE INDEX "ix_Document_isPartOf_Document_id" ON "Document_isPartOf" ("Document_id");
+CREATE INDEX "ix_Document_isPartOf_isPartOf_id" ON "Document_isPartOf" ("isPartOf_id");
+
+CREATE TABLE "Document_hasPart" (
+	"Document_id" TEXT,
+	"hasPart_id" TEXT,
+	PRIMARY KEY ("Document_id", "hasPart_id"),
+	FOREIGN KEY("Document_id") REFERENCES "Document" (id),
+	FOREIGN KEY("hasPart_id") REFERENCES "Concept" (id)
+);
+CREATE INDEX "ix_Document_hasPart_hasPart_id" ON "Document_hasPart" ("hasPart_id");
+CREATE INDEX "ix_Document_hasPart_Document_id" ON "Document_hasPart" ("Document_id");
+
+CREATE TABLE "Document_references" (
+	"Document_id" TEXT,
+	references_id TEXT,
+	PRIMARY KEY ("Document_id", references_id),
+	FOREIGN KEY("Document_id") REFERENCES "Document" (id),
+	FOREIGN KEY(references_id) REFERENCES "Concept" (id)
+);
+CREATE INDEX "ix_Document_references_Document_id" ON "Document_references" ("Document_id");
+CREATE INDEX "ix_Document_references_references_id" ON "Document_references" (references_id);
+
+CREATE TABLE "Document_dependsOn" (
+	"Document_id" TEXT,
+	"dependsOn_id" TEXT,
+	PRIMARY KEY ("Document_id", "dependsOn_id"),
+	FOREIGN KEY("Document_id") REFERENCES "Document" (id),
+	FOREIGN KEY("dependsOn_id") REFERENCES "Concept" (id)
+);
+CREATE INDEX "ix_Document_dependsOn_dependsOn_id" ON "Document_dependsOn" ("dependsOn_id");
+CREATE INDEX "ix_Document_dependsOn_Document_id" ON "Document_dependsOn" ("Document_id");
+
+CREATE TABLE "Document_derivedFrom" (
+	"Document_id" TEXT,
+	"derivedFrom_id" TEXT,
+	PRIMARY KEY ("Document_id", "derivedFrom_id"),
+	FOREIGN KEY("Document_id") REFERENCES "Document" (id),
+	FOREIGN KEY("derivedFrom_id") REFERENCES "Concept" (id)
+);
+CREATE INDEX "ix_Document_derivedFrom_Document_id" ON "Document_derivedFrom" ("Document_id");
+CREATE INDEX "ix_Document_derivedFrom_derivedFrom_id" ON "Document_derivedFrom" ("derivedFrom_id");
+
+CREATE TABLE "Document_about" (
+	"Document_id" TEXT,
+	about_id TEXT,
+	PRIMARY KEY ("Document_id", about_id),
+	FOREIGN KEY("Document_id") REFERENCES "Document" (id),
+	FOREIGN KEY(about_id) REFERENCES "Concept" (id)
+);
+CREATE INDEX "ix_Document_about_about_id" ON "Document_about" (about_id);
+CREATE INDEX "ix_Document_about_Document_id" ON "Document_about" ("Document_id");
+
+CREATE TABLE "Document_sameAs" (
+	"Document_id" TEXT,
+	"sameAs_id" TEXT,
+	PRIMARY KEY ("Document_id", "sameAs_id"),
+	FOREIGN KEY("Document_id") REFERENCES "Document" (id),
+	FOREIGN KEY("sameAs_id") REFERENCES "Concept" (id)
+);
+CREATE INDEX "ix_Document_sameAs_sameAs_id" ON "Document_sameAs" ("sameAs_id");
+CREATE INDEX "ix_Document_sameAs_Document_id" ON "Document_sameAs" ("Document_id");
+
+CREATE TABLE "Document_relatedTo" (
+	"Document_id" TEXT,
+	"relatedTo_id" TEXT,
+	PRIMARY KEY ("Document_id", "relatedTo_id"),
+	FOREIGN KEY("Document_id") REFERENCES "Document" (id),
+	FOREIGN KEY("relatedTo_id") REFERENCES "Concept" (id)
+);
+CREATE INDEX "ix_Document_relatedTo_Document_id" ON "Document_relatedTo" ("Document_id");
+CREATE INDEX "ix_Document_relatedTo_relatedTo_id" ON "Document_relatedTo" ("relatedTo_id");
+
+CREATE TABLE "Document_definedBy" (
+	"Document_id" TEXT,
+	"definedBy_id" TEXT,
+	PRIMARY KEY ("Document_id", "definedBy_id"),
+	FOREIGN KEY("Document_id") REFERENCES "Document" (id),
+	FOREIGN KEY("definedBy_id") REFERENCES "Concept" (id)
+);
+CREATE INDEX "ix_Document_definedBy_definedBy_id" ON "Document_definedBy" ("definedBy_id");
+CREATE INDEX "ix_Document_definedBy_Document_id" ON "Document_definedBy" ("Document_id");
+
+CREATE TABLE "Document_source" (
+	"Document_id" TEXT,
+	source_id TEXT,
+	PRIMARY KEY ("Document_id", source_id),
+	FOREIGN KEY("Document_id") REFERENCES "Document" (id),
+	FOREIGN KEY(source_id) REFERENCES "Concept" (id)
+);
+CREATE INDEX "ix_Document_source_source_id" ON "Document_source" (source_id);
+CREATE INDEX "ix_Document_source_Document_id" ON "Document_source" ("Document_id");
+
+CREATE TABLE "Role_memberOf" (
+	"Role_id" TEXT,
+	"memberOf_id" TEXT,
+	PRIMARY KEY ("Role_id", "memberOf_id"),
+	FOREIGN KEY("Role_id") REFERENCES "Role" (id),
+	FOREIGN KEY("memberOf_id") REFERENCES "Concept" (id)
+);
+CREATE INDEX "ix_Role_memberOf_memberOf_id" ON "Role_memberOf" ("memberOf_id");
+CREATE INDEX "ix_Role_memberOf_Role_id" ON "Role_memberOf" ("Role_id");
+
+CREATE TABLE "Role_holder" (
+	"Role_id" TEXT,
+	holder_id TEXT,
+	PRIMARY KEY ("Role_id", holder_id),
+	FOREIGN KEY("Role_id") REFERENCES "Role" (id),
+	FOREIGN KEY(holder_id) REFERENCES "Concept" (id)
+);
+CREATE INDEX "ix_Role_holder_Role_id" ON "Role_holder" ("Role_id");
+CREATE INDEX "ix_Role_holder_holder_id" ON "Role_holder" (holder_id);
+
+CREATE TABLE "Role_tags" (
+	"Role_id" TEXT,
+	tags TEXT,
+	PRIMARY KEY ("Role_id", tags),
+	FOREIGN KEY("Role_id") REFERENCES "Role" (id)
+);
+CREATE INDEX "ix_Role_tags_Role_id" ON "Role_tags" ("Role_id");
+CREATE INDEX "ix_Role_tags_tags" ON "Role_tags" (tags);
+
+CREATE TABLE "Role_isPartOf" (
+	"Role_id" TEXT,
+	"isPartOf_id" TEXT,
+	PRIMARY KEY ("Role_id", "isPartOf_id"),
+	FOREIGN KEY("Role_id") REFERENCES "Role" (id),
+	FOREIGN KEY("isPartOf_id") REFERENCES "Concept" (id)
+);
+CREATE INDEX "ix_Role_isPartOf_Role_id" ON "Role_isPartOf" ("Role_id");
+CREATE INDEX "ix_Role_isPartOf_isPartOf_id" ON "Role_isPartOf" ("isPartOf_id");
+
+CREATE TABLE "Role_hasPart" (
+	"Role_id" TEXT,
+	"hasPart_id" TEXT,
+	PRIMARY KEY ("Role_id", "hasPart_id"),
+	FOREIGN KEY("Role_id") REFERENCES "Role" (id),
+	FOREIGN KEY("hasPart_id") REFERENCES "Concept" (id)
+);
+CREATE INDEX "ix_Role_hasPart_hasPart_id" ON "Role_hasPart" ("hasPart_id");
+CREATE INDEX "ix_Role_hasPart_Role_id" ON "Role_hasPart" ("Role_id");
+
+CREATE TABLE "Role_references" (
+	"Role_id" TEXT,
+	references_id TEXT,
+	PRIMARY KEY ("Role_id", references_id),
+	FOREIGN KEY("Role_id") REFERENCES "Role" (id),
+	FOREIGN KEY(references_id) REFERENCES "Concept" (id)
+);
+CREATE INDEX "ix_Role_references_references_id" ON "Role_references" (references_id);
+CREATE INDEX "ix_Role_references_Role_id" ON "Role_references" ("Role_id");
+
+CREATE TABLE "Role_dependsOn" (
+	"Role_id" TEXT,
+	"dependsOn_id" TEXT,
+	PRIMARY KEY ("Role_id", "dependsOn_id"),
+	FOREIGN KEY("Role_id") REFERENCES "Role" (id),
+	FOREIGN KEY("dependsOn_id") REFERENCES "Concept" (id)
+);
+CREATE INDEX "ix_Role_dependsOn_dependsOn_id" ON "Role_dependsOn" ("dependsOn_id");
+CREATE INDEX "ix_Role_dependsOn_Role_id" ON "Role_dependsOn" ("Role_id");
+
+CREATE TABLE "Role_derivedFrom" (
+	"Role_id" TEXT,
+	"derivedFrom_id" TEXT,
+	PRIMARY KEY ("Role_id", "derivedFrom_id"),
+	FOREIGN KEY("Role_id") REFERENCES "Role" (id),
+	FOREIGN KEY("derivedFrom_id") REFERENCES "Concept" (id)
+);
+CREATE INDEX "ix_Role_derivedFrom_Role_id" ON "Role_derivedFrom" ("Role_id");
+CREATE INDEX "ix_Role_derivedFrom_derivedFrom_id" ON "Role_derivedFrom" ("derivedFrom_id");
+
+CREATE TABLE "Role_about" (
+	"Role_id" TEXT,
+	about_id TEXT,
+	PRIMARY KEY ("Role_id", about_id),
+	FOREIGN KEY("Role_id") REFERENCES "Role" (id),
+	FOREIGN KEY(about_id) REFERENCES "Concept" (id)
+);
+CREATE INDEX "ix_Role_about_Role_id" ON "Role_about" ("Role_id");
+CREATE INDEX "ix_Role_about_about_id" ON "Role_about" (about_id);
+
+CREATE TABLE "Role_sameAs" (
+	"Role_id" TEXT,
+	"sameAs_id" TEXT,
+	PRIMARY KEY ("Role_id", "sameAs_id"),
+	FOREIGN KEY("Role_id") REFERENCES "Role" (id),
+	FOREIGN KEY("sameAs_id") REFERENCES "Concept" (id)
+);
+CREATE INDEX "ix_Role_sameAs_Role_id" ON "Role_sameAs" ("Role_id");
+CREATE INDEX "ix_Role_sameAs_sameAs_id" ON "Role_sameAs" ("sameAs_id");
+
+CREATE TABLE "Role_relatedTo" (
+	"Role_id" TEXT,
+	"relatedTo_id" TEXT,
+	PRIMARY KEY ("Role_id", "relatedTo_id"),
+	FOREIGN KEY("Role_id") REFERENCES "Role" (id),
+	FOREIGN KEY("relatedTo_id") REFERENCES "Concept" (id)
+);
+CREATE INDEX "ix_Role_relatedTo_relatedTo_id" ON "Role_relatedTo" ("relatedTo_id");
+CREATE INDEX "ix_Role_relatedTo_Role_id" ON "Role_relatedTo" ("Role_id");
+
+CREATE TABLE "Role_definedBy" (
+	"Role_id" TEXT,
+	"definedBy_id" TEXT,
+	PRIMARY KEY ("Role_id", "definedBy_id"),
+	FOREIGN KEY("Role_id") REFERENCES "Role" (id),
+	FOREIGN KEY("definedBy_id") REFERENCES "Concept" (id)
+);
+CREATE INDEX "ix_Role_definedBy_definedBy_id" ON "Role_definedBy" ("definedBy_id");
+CREATE INDEX "ix_Role_definedBy_Role_id" ON "Role_definedBy" ("Role_id");
+
+CREATE TABLE "Role_source" (
+	"Role_id" TEXT,
+	source_id TEXT,
+	PRIMARY KEY ("Role_id", source_id),
+	FOREIGN KEY("Role_id") REFERENCES "Role" (id),
+	FOREIGN KEY(source_id) REFERENCES "Concept" (id)
+);
+CREATE INDEX "ix_Role_source_Role_id" ON "Role_source" ("Role_id");
+CREATE INDEX "ix_Role_source_source_id" ON "Role_source" (source_id);
+
+CREATE TABLE "Person_tags" (
+	"Person_id" TEXT,
+	tags TEXT,
+	PRIMARY KEY ("Person_id", tags),
+	FOREIGN KEY("Person_id") REFERENCES "Person" (id)
+);
+CREATE INDEX "ix_Person_tags_tags" ON "Person_tags" (tags);
+CREATE INDEX "ix_Person_tags_Person_id" ON "Person_tags" ("Person_id");
+
+CREATE TABLE "Person_isPartOf" (
+	"Person_id" TEXT,
+	"isPartOf_id" TEXT,
+	PRIMARY KEY ("Person_id", "isPartOf_id"),
+	FOREIGN KEY("Person_id") REFERENCES "Person" (id),
+	FOREIGN KEY("isPartOf_id") REFERENCES "Concept" (id)
+);
+CREATE INDEX "ix_Person_isPartOf_isPartOf_id" ON "Person_isPartOf" ("isPartOf_id");
+CREATE INDEX "ix_Person_isPartOf_Person_id" ON "Person_isPartOf" ("Person_id");
+
+CREATE TABLE "Person_hasPart" (
+	"Person_id" TEXT,
+	"hasPart_id" TEXT,
+	PRIMARY KEY ("Person_id", "hasPart_id"),
+	FOREIGN KEY("Person_id") REFERENCES "Person" (id),
+	FOREIGN KEY("hasPart_id") REFERENCES "Concept" (id)
+);
+CREATE INDEX "ix_Person_hasPart_Person_id" ON "Person_hasPart" ("Person_id");
+CREATE INDEX "ix_Person_hasPart_hasPart_id" ON "Person_hasPart" ("hasPart_id");
+
+CREATE TABLE "Person_references" (
+	"Person_id" TEXT,
+	references_id TEXT,
+	PRIMARY KEY ("Person_id", references_id),
+	FOREIGN KEY("Person_id") REFERENCES "Person" (id),
+	FOREIGN KEY(references_id) REFERENCES "Concept" (id)
+);
+CREATE INDEX "ix_Person_references_Person_id" ON "Person_references" ("Person_id");
+CREATE INDEX "ix_Person_references_references_id" ON "Person_references" (references_id);
+
+CREATE TABLE "Person_dependsOn" (
+	"Person_id" TEXT,
+	"dependsOn_id" TEXT,
+	PRIMARY KEY ("Person_id", "dependsOn_id"),
+	FOREIGN KEY("Person_id") REFERENCES "Person" (id),
+	FOREIGN KEY("dependsOn_id") REFERENCES "Concept" (id)
+);
+CREATE INDEX "ix_Person_dependsOn_dependsOn_id" ON "Person_dependsOn" ("dependsOn_id");
+CREATE INDEX "ix_Person_dependsOn_Person_id" ON "Person_dependsOn" ("Person_id");
+
+CREATE TABLE "Person_derivedFrom" (
+	"Person_id" TEXT,
+	"derivedFrom_id" TEXT,
+	PRIMARY KEY ("Person_id", "derivedFrom_id"),
+	FOREIGN KEY("Person_id") REFERENCES "Person" (id),
+	FOREIGN KEY("derivedFrom_id") REFERENCES "Concept" (id)
+);
+CREATE INDEX "ix_Person_derivedFrom_derivedFrom_id" ON "Person_derivedFrom" ("derivedFrom_id");
+CREATE INDEX "ix_Person_derivedFrom_Person_id" ON "Person_derivedFrom" ("Person_id");
+
+CREATE TABLE "Person_about" (
+	"Person_id" TEXT,
+	about_id TEXT,
+	PRIMARY KEY ("Person_id", about_id),
+	FOREIGN KEY("Person_id") REFERENCES "Person" (id),
+	FOREIGN KEY(about_id) REFERENCES "Concept" (id)
+);
+CREATE INDEX "ix_Person_about_Person_id" ON "Person_about" ("Person_id");
+CREATE INDEX "ix_Person_about_about_id" ON "Person_about" (about_id);
+
+CREATE TABLE "Person_sameAs" (
+	"Person_id" TEXT,
+	"sameAs_id" TEXT,
+	PRIMARY KEY ("Person_id", "sameAs_id"),
+	FOREIGN KEY("Person_id") REFERENCES "Person" (id),
+	FOREIGN KEY("sameAs_id") REFERENCES "Concept" (id)
+);
+CREATE INDEX "ix_Person_sameAs_sameAs_id" ON "Person_sameAs" ("sameAs_id");
+CREATE INDEX "ix_Person_sameAs_Person_id" ON "Person_sameAs" ("Person_id");
+
+CREATE TABLE "Person_relatedTo" (
+	"Person_id" TEXT,
+	"relatedTo_id" TEXT,
+	PRIMARY KEY ("Person_id", "relatedTo_id"),
+	FOREIGN KEY("Person_id") REFERENCES "Person" (id),
+	FOREIGN KEY("relatedTo_id") REFERENCES "Concept" (id)
+);
+CREATE INDEX "ix_Person_relatedTo_relatedTo_id" ON "Person_relatedTo" ("relatedTo_id");
+CREATE INDEX "ix_Person_relatedTo_Person_id" ON "Person_relatedTo" ("Person_id");
+
+CREATE TABLE "Person_definedBy" (
+	"Person_id" TEXT,
+	"definedBy_id" TEXT,
+	PRIMARY KEY ("Person_id", "definedBy_id"),
+	FOREIGN KEY("Person_id") REFERENCES "Person" (id),
+	FOREIGN KEY("definedBy_id") REFERENCES "Concept" (id)
+);
+CREATE INDEX "ix_Person_definedBy_Person_id" ON "Person_definedBy" ("Person_id");
+CREATE INDEX "ix_Person_definedBy_definedBy_id" ON "Person_definedBy" ("definedBy_id");
+
+CREATE TABLE "Person_source" (
+	"Person_id" TEXT,
+	source_id TEXT,
+	PRIMARY KEY ("Person_id", source_id),
+	FOREIGN KEY("Person_id") REFERENCES "Person" (id),
+	FOREIGN KEY(source_id) REFERENCES "Concept" (id)
+);
+CREATE INDEX "ix_Person_source_source_id" ON "Person_source" (source_id);
+CREATE INDEX "ix_Person_source_Person_id" ON "Person_source" ("Person_id");
+
+CREATE TABLE "Organization_tags" (
+	"Organization_id" TEXT,
+	tags TEXT,
+	PRIMARY KEY ("Organization_id", tags),
+	FOREIGN KEY("Organization_id") REFERENCES "Organization" (id)
+);
+CREATE INDEX "ix_Organization_tags_tags" ON "Organization_tags" (tags);
+CREATE INDEX "ix_Organization_tags_Organization_id" ON "Organization_tags" ("Organization_id");
+
+CREATE TABLE "Organization_isPartOf" (
+	"Organization_id" TEXT,
+	"isPartOf_id" TEXT,
+	PRIMARY KEY ("Organization_id", "isPartOf_id"),
+	FOREIGN KEY("Organization_id") REFERENCES "Organization" (id),
+	FOREIGN KEY("isPartOf_id") REFERENCES "Concept" (id)
+);
+CREATE INDEX "ix_Organization_isPartOf_isPartOf_id" ON "Organization_isPartOf" ("isPartOf_id");
+CREATE INDEX "ix_Organization_isPartOf_Organization_id" ON "Organization_isPartOf" ("Organization_id");
+
+CREATE TABLE "Organization_hasPart" (
+	"Organization_id" TEXT,
+	"hasPart_id" TEXT,
+	PRIMARY KEY ("Organization_id", "hasPart_id"),
+	FOREIGN KEY("Organization_id") REFERENCES "Organization" (id),
+	FOREIGN KEY("hasPart_id") REFERENCES "Concept" (id)
+);
+CREATE INDEX "ix_Organization_hasPart_hasPart_id" ON "Organization_hasPart" ("hasPart_id");
+CREATE INDEX "ix_Organization_hasPart_Organization_id" ON "Organization_hasPart" ("Organization_id");
+
+CREATE TABLE "Organization_references" (
+	"Organization_id" TEXT,
+	references_id TEXT,
+	PRIMARY KEY ("Organization_id", references_id),
+	FOREIGN KEY("Organization_id") REFERENCES "Organization" (id),
+	FOREIGN KEY(references_id) REFERENCES "Concept" (id)
+);
+CREATE INDEX "ix_Organization_references_Organization_id" ON "Organization_references" ("Organization_id");
+CREATE INDEX "ix_Organization_references_references_id" ON "Organization_references" (references_id);
+
+CREATE TABLE "Organization_dependsOn" (
+	"Organization_id" TEXT,
+	"dependsOn_id" TEXT,
+	PRIMARY KEY ("Organization_id", "dependsOn_id"),
+	FOREIGN KEY("Organization_id") REFERENCES "Organization" (id),
+	FOREIGN KEY("dependsOn_id") REFERENCES "Concept" (id)
+);
+CREATE INDEX "ix_Organization_dependsOn_dependsOn_id" ON "Organization_dependsOn" ("dependsOn_id");
+CREATE INDEX "ix_Organization_dependsOn_Organization_id" ON "Organization_dependsOn" ("Organization_id");
+
+CREATE TABLE "Organization_derivedFrom" (
+	"Organization_id" TEXT,
+	"derivedFrom_id" TEXT,
+	PRIMARY KEY ("Organization_id", "derivedFrom_id"),
+	FOREIGN KEY("Organization_id") REFERENCES "Organization" (id),
+	FOREIGN KEY("derivedFrom_id") REFERENCES "Concept" (id)
+);
+CREATE INDEX "ix_Organization_derivedFrom_Organization_id" ON "Organization_derivedFrom" ("Organization_id");
+CREATE INDEX "ix_Organization_derivedFrom_derivedFrom_id" ON "Organization_derivedFrom" ("derivedFrom_id");
+
+CREATE TABLE "Organization_about" (
+	"Organization_id" TEXT,
+	about_id TEXT,
+	PRIMARY KEY ("Organization_id", about_id),
+	FOREIGN KEY("Organization_id") REFERENCES "Organization" (id),
+	FOREIGN KEY(about_id) REFERENCES "Concept" (id)
+);
+CREATE INDEX "ix_Organization_about_about_id" ON "Organization_about" (about_id);
+CREATE INDEX "ix_Organization_about_Organization_id" ON "Organization_about" ("Organization_id");
+
+CREATE TABLE "Organization_sameAs" (
+	"Organization_id" TEXT,
+	"sameAs_id" TEXT,
+	PRIMARY KEY ("Organization_id", "sameAs_id"),
+	FOREIGN KEY("Organization_id") REFERENCES "Organization" (id),
+	FOREIGN KEY("sameAs_id") REFERENCES "Concept" (id)
+);
+CREATE INDEX "ix_Organization_sameAs_sameAs_id" ON "Organization_sameAs" ("sameAs_id");
+CREATE INDEX "ix_Organization_sameAs_Organization_id" ON "Organization_sameAs" ("Organization_id");
+
+CREATE TABLE "Organization_relatedTo" (
+	"Organization_id" TEXT,
+	"relatedTo_id" TEXT,
+	PRIMARY KEY ("Organization_id", "relatedTo_id"),
+	FOREIGN KEY("Organization_id") REFERENCES "Organization" (id),
+	FOREIGN KEY("relatedTo_id") REFERENCES "Concept" (id)
+);
+CREATE INDEX "ix_Organization_relatedTo_Organization_id" ON "Organization_relatedTo" ("Organization_id");
+CREATE INDEX "ix_Organization_relatedTo_relatedTo_id" ON "Organization_relatedTo" ("relatedTo_id");
+
+CREATE TABLE "Organization_definedBy" (
+	"Organization_id" TEXT,
+	"definedBy_id" TEXT,
+	PRIMARY KEY ("Organization_id", "definedBy_id"),
+	FOREIGN KEY("Organization_id") REFERENCES "Organization" (id),
+	FOREIGN KEY("definedBy_id") REFERENCES "Concept" (id)
+);
+CREATE INDEX "ix_Organization_definedBy_definedBy_id" ON "Organization_definedBy" ("definedBy_id");
+CREATE INDEX "ix_Organization_definedBy_Organization_id" ON "Organization_definedBy" ("Organization_id");
+
+CREATE TABLE "Organization_source" (
+	"Organization_id" TEXT,
+	source_id TEXT,
+	PRIMARY KEY ("Organization_id", source_id),
+	FOREIGN KEY("Organization_id") REFERENCES "Organization" (id),
+	FOREIGN KEY(source_id) REFERENCES "Concept" (id)
+);
+CREATE INDEX "ix_Organization_source_Organization_id" ON "Organization_source" ("Organization_id");
+CREATE INDEX "ix_Organization_source_source_id" ON "Organization_source" (source_id);
+

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,6 +30,10 @@ dependencies = [
     "typer>=0.15",
     "pyoxigraph>=0.4",
     "mcp>=1.2",
+    # Runtime for the generated dataclass bindings (src/lokf/datamodel.py).
+    # linkml_runtime is light; the heavy `linkml` generator stays in the
+    # `build` extra used only to regenerate artifacts.
+    "linkml-runtime>=1.8",
 ]
 
 [project.optional-dependencies]

--- a/src/lokf/build.py
+++ b/src/lokf/build.py
@@ -13,6 +13,8 @@ Outputs (regenerated in place):
     lokf.schema.json      JSON Schema
     lokf.shacl.ttl        SHACL shapes
     lokf.owl.ttl          OWL ontology
+    lokf.sql              relational schema (CREATE TABLE DDL)
+    src/lokf/datamodel.py LinkML dataclass bindings (from lokf.datamodel import ...)
     examples/acme-knowledge.bundle.json   assembled bundle (git-ignored)
     examples/acme-knowledge.nt            RDF triples for the whole bundle
     examples/weekly-active-users.nt       RDF triples for one concept
@@ -63,6 +65,12 @@ def generate(root: pathlib.Path) -> None:
     with open(root / "lokf.shacl.ttl", "w") as f:
         run(["gen-shacl", str(schema)], stdout=f)
 
+    # The relational projection of the schema: CREATE TABLE DDL with foreign
+    # keys auto-created for the typed relations. The instance-level counterpart
+    # (a bundle -> linked DataFrames/SQL) lives in ``lokf.tables``.
+    with open(root / "lokf.sql", "w") as f:
+        run(["gen-sqltables", str(schema)], stdout=f)
+
     base = root / "lokf.context.base.jsonld"
     with open(base, "w") as f:
         run(["gen-jsonld-context", str(schema)], stdout=f)
@@ -85,13 +93,19 @@ def generate(root: pathlib.Path) -> None:
     # is self-sufficient (see lokf.schema's resolution order). Only when run
     # inside the lokf repo itself: a downstream knowledge repo that satisfies
     # _find_root must not have a src/lokf/ tree planted in it.
-    outputs = "  -> lokf.context.jsonld, lokf.schema.json, lokf.shacl.ttl, lokf.owl.ttl"
+    outputs = "  -> lokf.context.jsonld, lokf.schema.json, lokf.shacl.ttl, lokf.owl.ttl, lokf.sql"
     if (root / "src" / "lokf" / "__init__.py").exists():
         data = root / "src" / "lokf" / "data"
         data.mkdir(parents=True, exist_ok=True)
         shutil.copy(root / "lokf.yaml", data / "lokf.yaml")
         shutil.copy(root / "lokf.context.jsonld", data / "lokf.context.jsonld")
-        outputs += " (+ src/lokf/data copies)"
+        # Typed Python bindings for the vocabulary: `from lokf.datamodel import
+        # Metric`, etc. LinkML dataclasses (backed by linkml_runtime) that
+        # validate required fields and round-trip to JSON / YAML / RDF.
+        # Committed so an installed wheel ships them.
+        with open(root / "src" / "lokf" / "datamodel.py", "w") as f:
+            run(["gen-python", str(schema)], stdout=f)
+        outputs += " (+ src/lokf/data copies + datamodel.py)"
     print(outputs)
 
 

--- a/src/lokf/datamodel.py
+++ b/src/lokf/datamodel.py
@@ -1,0 +1,1406 @@
+# Auto generated from lokf.yaml by pythongen.py version: 0.0.1
+# Generation date: 2026-07-04T07:42:18
+# Schema: lokf
+#
+# id: https://w3id.org/lokf/schema
+# description: LOKF is a semantic, ontology-grounded profile of the Google Open Knowledge Format (OKF v0.1). It preserves OKF's authoring model — a directory of markdown files, each with a small YAML frontmatter block describing one concept — but binds every concept, field, and relationship to established web vocabularies (schema.org, W3C DCAT, and W3C PROV-O). Because the frontmatter keys are LinkML slots mapped to IRIs, a LOKF concept file, once a LinkML-generated JSON-LD @context is attached, is simultaneously human-readable markdown AND valid JSON-LD that expands losslessly to RDF triples. The entire format is defined in this single LinkML schema, from which the JSON-LD context, JSON Schema, SHACL shapes, and an OWL ontology are generated.
+# license: https://creativecommons.org/licenses/by/4.0/
+
+import dataclasses
+import re
+from dataclasses import dataclass
+from datetime import (
+    date,
+    datetime,
+    time
+)
+from typing import (
+    Any,
+    ClassVar,
+    Dict,
+    List,
+    Optional,
+    Union
+)
+
+from jsonasobj2 import (
+    JsonObj,
+    as_dict
+)
+from linkml_runtime.linkml_model.meta import (
+    EnumDefinition,
+    PermissibleValue,
+    PvFormulaOptions
+)
+from linkml_runtime.utils.curienamespace import CurieNamespace
+from linkml_runtime.utils.enumerations import EnumDefinitionImpl
+from linkml_runtime.utils.formatutils import (
+    camelcase,
+    sfx,
+    underscore
+)
+from linkml_runtime.utils.metamodelcore import (
+    bnode,
+    empty_dict,
+    empty_list
+)
+from linkml_runtime.utils.slot import Slot
+from linkml_runtime.utils.yamlutils import (
+    YAMLRoot,
+    extended_float,
+    extended_int,
+    extended_str
+)
+from rdflib import (
+    Namespace,
+    URIRef
+)
+
+from linkml_runtime.linkml_model.types import Boolean, Datetime, String, Uri, Uriorcurie
+from linkml_runtime.utils.metamodelcore import Bool, URI, URIorCURIE, XSDDateTime
+
+metamodel_version = "1.11.0"
+version = "0.1.0"
+
+# Namespaces
+DCAT = CurieNamespace('dcat', 'http://www.w3.org/ns/dcat#')
+DCTERMS = CurieNamespace('dcterms', 'http://purl.org/dc/terms/')
+FOAF = CurieNamespace('foaf', 'http://xmlns.com/foaf/0.1/')
+LINKML = CurieNamespace('linkml', 'https://w3id.org/linkml/')
+LOKF = CurieNamespace('lokf', 'https://w3id.org/lokf/')
+ORG = CurieNamespace('org', 'http://www.w3.org/ns/org#')
+OWL = CurieNamespace('owl', 'http://www.w3.org/2002/07/owl#')
+PAV = CurieNamespace('pav', 'http://purl.org/pav/')
+PROV = CurieNamespace('prov', 'http://www.w3.org/ns/prov#')
+RDF = CurieNamespace('rdf', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#')
+RDFS = CurieNamespace('rdfs', 'http://www.w3.org/2000/01/rdf-schema#')
+SCHEMA = CurieNamespace('schema', 'http://schema.org/')
+SKOS = CurieNamespace('skos', 'http://www.w3.org/2004/02/skos/core#')
+VIVO = CurieNamespace('vivo', 'http://vivoweb.org/ontology/core#')
+XSD = CurieNamespace('xsd', 'http://www.w3.org/2001/XMLSchema#')
+DEFAULT_ = LOKF
+
+
+# Types
+
+# Class references
+class ConceptId(URIorCURIE):
+    pass
+
+
+class DatasetId(ConceptId):
+    pass
+
+
+class TableId(DatasetId):
+    pass
+
+
+class MetricId(ConceptId):
+    pass
+
+
+class ServiceId(ConceptId):
+    pass
+
+
+class PlaybookId(ConceptId):
+    pass
+
+
+class PolicyId(ConceptId):
+    pass
+
+
+class GlossaryTermId(ConceptId):
+    pass
+
+
+class ReferenceId(ConceptId):
+    pass
+
+
+class DocumentId(ConceptId):
+    pass
+
+
+class RoleId(ConceptId):
+    pass
+
+
+class AgentId(URIorCURIE):
+    pass
+
+
+class PersonId(AgentId):
+    pass
+
+
+class OrganizationId(AgentId):
+    pass
+
+
+@dataclass(repr=False)
+class KnowledgeBundle(YAMLRoot):
+    """
+    A self-contained, hierarchical collection of concept documents — the unit of distribution (a git repo, tarball, or
+    subdirectory). Maps to a DCAT Catalog. When a whole bundle is serialized as a single JSON-LD document, this class
+    is the tree root; individual concept files validate against Concept (or a subclass).
+    """
+    _inherited_slots: ClassVar[list[str]] = []
+
+    class_class_uri: ClassVar[URIRef] = LOKF["KnowledgeBundle"]
+    class_class_curie: ClassVar[str] = "lokf:KnowledgeBundle"
+    class_name: ClassVar[str] = "KnowledgeBundle"
+    class_model_uri: ClassVar[URIRef] = LOKF.KnowledgeBundle
+
+    lokf_version: Optional[str] = None
+    okf_version: Optional[str] = None
+    base_iri: Optional[Union[str, URI]] = None
+    context: Optional[Union[str, URI]] = None
+    title: Optional[str] = None
+    description: Optional[str] = None
+    license: Optional[Union[str, URIorCURIE]] = None
+    publisher: Optional[Union[dict, "Agent"]] = None
+    concepts: Optional[Union[dict[Union[str, ConceptId], Union[dict, "Concept"]], list[Union[dict, "Concept"]]]] = empty_dict()
+
+    def __post_init__(self, *_: str, **kwargs: Any):
+        if self.lokf_version is not None and not isinstance(self.lokf_version, str):
+            self.lokf_version = str(self.lokf_version)
+
+        if self.okf_version is not None and not isinstance(self.okf_version, str):
+            self.okf_version = str(self.okf_version)
+
+        if self.base_iri is not None and not isinstance(self.base_iri, URI):
+            self.base_iri = URI(self.base_iri)
+
+        if self.context is not None and not isinstance(self.context, URI):
+            self.context = URI(self.context)
+
+        if self.title is not None and not isinstance(self.title, str):
+            self.title = str(self.title)
+
+        if self.description is not None and not isinstance(self.description, str):
+            self.description = str(self.description)
+
+        if self.license is not None and not isinstance(self.license, URIorCURIE):
+            self.license = URIorCURIE(self.license)
+
+        if self.publisher is not None and not isinstance(self.publisher, Agent):
+            self.publisher = Agent(**as_dict(self.publisher))
+
+        self._normalize_inlined_as_list(slot_name="concepts", slot_type=Concept, key_name="id", keyed=True)
+
+        super().__post_init__(**kwargs)
+
+
+@dataclass(repr=False)
+class Concept(YAMLRoot):
+    """
+    A single unit of knowledge within a bundle, represented as one markdown document. The abstract base of every LOKF
+    type. Its own IRI (`id`) is the RDF subject; the markdown body and typed relations become triples about that
+    subject.
+    """
+    _inherited_slots: ClassVar[list[str]] = []
+
+    class_class_uri: ClassVar[URIRef] = LOKF["Concept"]
+    class_class_curie: ClassVar[str] = "lokf:Concept"
+    class_name: ClassVar[str] = "Concept"
+    class_model_uri: ClassVar[URIRef] = LOKF.Concept
+
+    id: Union[str, ConceptId] = None
+    type: str = None
+    title: Optional[str] = None
+    description: Optional[str] = None
+    resource: Optional[Union[str, URIorCURIE]] = None
+    tags: Optional[Union[str, list[str]]] = empty_list()
+    timestamp: Optional[Union[str, XSDDateTime]] = None
+    created: Optional[Union[str, XSDDateTime]] = None
+    version: Optional[str] = None
+    license: Optional[Union[str, URIorCURIE]] = None
+    author: Optional[Union[dict[Union[str, AgentId], Union[dict, "Agent"]], list[Union[dict, "Agent"]]]] = empty_dict()
+    body: Optional[str] = None
+    citations: Optional[Union[Union[dict, "Citation"], list[Union[dict, "Citation"]]]] = empty_list()
+    relations: Optional[Union[Union[dict, "Relation"], list[Union[dict, "Relation"]]]] = empty_list()
+    isPartOf: Optional[Union[Union[str, ConceptId], list[Union[str, ConceptId]]]] = empty_list()
+    hasPart: Optional[Union[Union[str, ConceptId], list[Union[str, ConceptId]]]] = empty_list()
+    references: Optional[Union[Union[str, ConceptId], list[Union[str, ConceptId]]]] = empty_list()
+    dependsOn: Optional[Union[Union[str, ConceptId], list[Union[str, ConceptId]]]] = empty_list()
+    derivedFrom: Optional[Union[Union[str, ConceptId], list[Union[str, ConceptId]]]] = empty_list()
+    about: Optional[Union[Union[str, ConceptId], list[Union[str, ConceptId]]]] = empty_list()
+    sameAs: Optional[Union[Union[str, ConceptId], list[Union[str, ConceptId]]]] = empty_list()
+    relatedTo: Optional[Union[Union[str, ConceptId], list[Union[str, ConceptId]]]] = empty_list()
+    definedBy: Optional[Union[Union[str, ConceptId], list[Union[str, ConceptId]]]] = empty_list()
+    source: Optional[Union[Union[str, ConceptId], list[Union[str, ConceptId]]]] = empty_list()
+
+    def __post_init__(self, *_: str, **kwargs: Any):
+        if self._is_empty(self.id):
+            self.MissingRequiredField("id")
+        if not isinstance(self.id, ConceptId):
+            self.id = ConceptId(self.id)
+
+        if self._is_empty(self.type):
+            self.MissingRequiredField("type")
+        self.type = str(self.class_name)
+
+        if self.title is not None and not isinstance(self.title, str):
+            self.title = str(self.title)
+
+        if self.description is not None and not isinstance(self.description, str):
+            self.description = str(self.description)
+
+        if self.resource is not None and not isinstance(self.resource, URIorCURIE):
+            self.resource = URIorCURIE(self.resource)
+
+        if not isinstance(self.tags, list):
+            self.tags = [self.tags] if self.tags is not None else []
+        self.tags = [v if isinstance(v, str) else str(v) for v in self.tags]
+
+        if self.timestamp is not None and not isinstance(self.timestamp, XSDDateTime):
+            self.timestamp = XSDDateTime(self.timestamp)
+
+        if self.created is not None and not isinstance(self.created, XSDDateTime):
+            self.created = XSDDateTime(self.created)
+
+        if self.version is not None and not isinstance(self.version, str):
+            self.version = str(self.version)
+
+        if self.license is not None and not isinstance(self.license, URIorCURIE):
+            self.license = URIorCURIE(self.license)
+
+        self._normalize_inlined_as_list(slot_name="author", slot_type=Agent, key_name="id", keyed=True)
+
+        if self.body is not None and not isinstance(self.body, str):
+            self.body = str(self.body)
+
+        if not isinstance(self.citations, list):
+            self.citations = [self.citations] if self.citations is not None else []
+        self.citations = [v if isinstance(v, Citation) else Citation(**as_dict(v)) for v in self.citations]
+
+        self._normalize_inlined_as_list(slot_name="relations", slot_type=Relation, key_name="predicate", keyed=False)
+
+        if not isinstance(self.isPartOf, list):
+            self.isPartOf = [self.isPartOf] if self.isPartOf is not None else []
+        self.isPartOf = [v if isinstance(v, ConceptId) else ConceptId(v) for v in self.isPartOf]
+
+        if not isinstance(self.hasPart, list):
+            self.hasPart = [self.hasPart] if self.hasPart is not None else []
+        self.hasPart = [v if isinstance(v, ConceptId) else ConceptId(v) for v in self.hasPart]
+
+        if not isinstance(self.references, list):
+            self.references = [self.references] if self.references is not None else []
+        self.references = [v if isinstance(v, ConceptId) else ConceptId(v) for v in self.references]
+
+        if not isinstance(self.dependsOn, list):
+            self.dependsOn = [self.dependsOn] if self.dependsOn is not None else []
+        self.dependsOn = [v if isinstance(v, ConceptId) else ConceptId(v) for v in self.dependsOn]
+
+        if not isinstance(self.derivedFrom, list):
+            self.derivedFrom = [self.derivedFrom] if self.derivedFrom is not None else []
+        self.derivedFrom = [v if isinstance(v, ConceptId) else ConceptId(v) for v in self.derivedFrom]
+
+        if not isinstance(self.about, list):
+            self.about = [self.about] if self.about is not None else []
+        self.about = [v if isinstance(v, ConceptId) else ConceptId(v) for v in self.about]
+
+        if not isinstance(self.sameAs, list):
+            self.sameAs = [self.sameAs] if self.sameAs is not None else []
+        self.sameAs = [v if isinstance(v, ConceptId) else ConceptId(v) for v in self.sameAs]
+
+        if not isinstance(self.relatedTo, list):
+            self.relatedTo = [self.relatedTo] if self.relatedTo is not None else []
+        self.relatedTo = [v if isinstance(v, ConceptId) else ConceptId(v) for v in self.relatedTo]
+
+        if not isinstance(self.definedBy, list):
+            self.definedBy = [self.definedBy] if self.definedBy is not None else []
+        self.definedBy = [v if isinstance(v, ConceptId) else ConceptId(v) for v in self.definedBy]
+
+        if not isinstance(self.source, list):
+            self.source = [self.source] if self.source is not None else []
+        self.source = [v if isinstance(v, ConceptId) else ConceptId(v) for v in self.source]
+
+        super().__post_init__(**kwargs)
+
+
+    def __new__(cls, *args, **kwargs):
+
+        type_designator = "type"
+        if not type_designator in kwargs:
+            return super().__new__(cls,*args,**kwargs)
+        else:
+            type_designator_value = kwargs[type_designator]
+            target_cls = cls._class_for("class_name", type_designator_value)
+
+
+            if target_cls is None:
+                raise ValueError(f"Wrong type designator value: class {cls.__name__} "
+                                 f"has no subclass with ['class_name']='{kwargs[type_designator]}'")
+            return super().__new__(target_cls,*args,**kwargs)
+
+
+
+@dataclass(repr=False)
+class Dataset(Concept):
+    """
+    A collection of data, published or curated for access and reuse.
+    """
+    _inherited_slots: ClassVar[list[str]] = []
+
+    class_class_uri: ClassVar[URIRef] = SCHEMA["Dataset"]
+    class_class_curie: ClassVar[str] = "schema:Dataset"
+    class_name: ClassVar[str] = "Dataset"
+    class_model_uri: ClassVar[URIRef] = LOKF.Dataset
+
+    id: Union[str, DatasetId] = None
+    type: str = None
+    distribution: Optional[Union[Union[dict, "Distribution"], list[Union[dict, "Distribution"]]]] = empty_list()
+    fields: Optional[Union[Union[dict, "Field"], list[Union[dict, "Field"]]]] = empty_list()
+
+    def __post_init__(self, *_: str, **kwargs: Any):
+        if self._is_empty(self.id):
+            self.MissingRequiredField("id")
+        if not isinstance(self.id, DatasetId):
+            self.id = DatasetId(self.id)
+
+        if not isinstance(self.distribution, list):
+            self.distribution = [self.distribution] if self.distribution is not None else []
+        self.distribution = [v if isinstance(v, Distribution) else Distribution(**as_dict(v)) for v in self.distribution]
+
+        if not isinstance(self.fields, list):
+            self.fields = [self.fields] if self.fields is not None else []
+        self.fields = [v if isinstance(v, Field) else Field(**as_dict(v)) for v in self.fields]
+
+        super().__post_init__(**kwargs)
+        if self._is_empty(self.type):
+            self.MissingRequiredField("type")
+        self.type = str(self.class_name)
+
+
+@dataclass(repr=False)
+class Table(Dataset):
+    """
+    A structured, tabular dataset (e.g. a warehouse table or view) whose columns are described by Field objects under
+    `fields`.
+    """
+    _inherited_slots: ClassVar[list[str]] = []
+
+    class_class_uri: ClassVar[URIRef] = LOKF["Table"]
+    class_class_curie: ClassVar[str] = "lokf:Table"
+    class_name: ClassVar[str] = "Table"
+    class_model_uri: ClassVar[URIRef] = LOKF.Table
+
+    id: Union[str, TableId] = None
+    type: str = None
+
+    def __post_init__(self, *_: str, **kwargs: Any):
+        if self._is_empty(self.id):
+            self.MissingRequiredField("id")
+        if not isinstance(self.id, TableId):
+            self.id = TableId(self.id)
+
+        super().__post_init__(**kwargs)
+        if self._is_empty(self.type):
+            self.MissingRequiredField("type")
+        self.type = str(self.class_name)
+
+
+@dataclass(repr=False)
+class Metric(Concept):
+    """
+    A precisely defined, measurable quantity — the canonical definition of a business or operational metric.
+    """
+    _inherited_slots: ClassVar[list[str]] = []
+
+    class_class_uri: ClassVar[URIRef] = LOKF["Metric"]
+    class_class_curie: ClassVar[str] = "lokf:Metric"
+    class_name: ClassVar[str] = "Metric"
+    class_model_uri: ClassVar[URIRef] = LOKF.Metric
+
+    id: Union[str, MetricId] = None
+    type: str = None
+    unit: Optional[str] = None
+    formula: Optional[str] = None
+    measures: Optional[Union[Union[str, ConceptId], list[Union[str, ConceptId]]]] = empty_list()
+
+    def __post_init__(self, *_: str, **kwargs: Any):
+        if self._is_empty(self.id):
+            self.MissingRequiredField("id")
+        if not isinstance(self.id, MetricId):
+            self.id = MetricId(self.id)
+
+        if self.unit is not None and not isinstance(self.unit, str):
+            self.unit = str(self.unit)
+
+        if self.formula is not None and not isinstance(self.formula, str):
+            self.formula = str(self.formula)
+
+        if not isinstance(self.measures, list):
+            self.measures = [self.measures] if self.measures is not None else []
+        self.measures = [v if isinstance(v, ConceptId) else ConceptId(v) for v in self.measures]
+
+        super().__post_init__(**kwargs)
+        if self._is_empty(self.type):
+            self.MissingRequiredField("type")
+        self.type = str(self.class_name)
+
+
+@dataclass(repr=False)
+class Service(Concept):
+    """
+    A callable service or API endpoint.
+    """
+    _inherited_slots: ClassVar[list[str]] = []
+
+    class_class_uri: ClassVar[URIRef] = SCHEMA["WebAPI"]
+    class_class_curie: ClassVar[str] = "schema:WebAPI"
+    class_name: ClassVar[str] = "Service"
+    class_model_uri: ClassVar[URIRef] = LOKF.Service
+
+    id: Union[str, ServiceId] = None
+    type: str = None
+    endpoint: Optional[Union[str, URIorCURIE]] = None
+    http_method: Optional[str] = None
+    documentation: Optional[Union[str, URIorCURIE]] = None
+
+    def __post_init__(self, *_: str, **kwargs: Any):
+        if self._is_empty(self.id):
+            self.MissingRequiredField("id")
+        if not isinstance(self.id, ServiceId):
+            self.id = ServiceId(self.id)
+
+        if self.endpoint is not None and not isinstance(self.endpoint, URIorCURIE):
+            self.endpoint = URIorCURIE(self.endpoint)
+
+        if self.http_method is not None and not isinstance(self.http_method, str):
+            self.http_method = str(self.http_method)
+
+        if self.documentation is not None and not isinstance(self.documentation, URIorCURIE):
+            self.documentation = URIorCURIE(self.documentation)
+
+        super().__post_init__(**kwargs)
+        if self._is_empty(self.type):
+            self.MissingRequiredField("type")
+        self.type = str(self.class_name)
+
+
+@dataclass(repr=False)
+class Playbook(Concept):
+    """
+    A procedure or runbook — an ordered set of steps to accomplish a task or respond to an event.
+    """
+    _inherited_slots: ClassVar[list[str]] = []
+
+    class_class_uri: ClassVar[URIRef] = LOKF["Playbook"]
+    class_class_curie: ClassVar[str] = "lokf:Playbook"
+    class_name: ClassVar[str] = "Playbook"
+    class_model_uri: ClassVar[URIRef] = LOKF.Playbook
+
+    id: Union[str, PlaybookId] = None
+    type: str = None
+
+    def __post_init__(self, *_: str, **kwargs: Any):
+        if self._is_empty(self.id):
+            self.MissingRequiredField("id")
+        if not isinstance(self.id, PlaybookId):
+            self.id = PlaybookId(self.id)
+
+        super().__post_init__(**kwargs)
+        if self._is_empty(self.type):
+            self.MissingRequiredField("type")
+        self.type = str(self.class_name)
+
+
+@dataclass(repr=False)
+class Policy(Concept):
+    """
+    A governance, compliance, or operational policy document.
+    """
+    _inherited_slots: ClassVar[list[str]] = []
+
+    class_class_uri: ClassVar[URIRef] = LOKF["Policy"]
+    class_class_curie: ClassVar[str] = "lokf:Policy"
+    class_name: ClassVar[str] = "Policy"
+    class_model_uri: ClassVar[URIRef] = LOKF.Policy
+
+    id: Union[str, PolicyId] = None
+    type: str = None
+
+    def __post_init__(self, *_: str, **kwargs: Any):
+        if self._is_empty(self.id):
+            self.MissingRequiredField("id")
+        if not isinstance(self.id, PolicyId):
+            self.id = PolicyId(self.id)
+
+        super().__post_init__(**kwargs)
+        if self._is_empty(self.type):
+            self.MissingRequiredField("type")
+        self.type = str(self.class_name)
+
+
+@dataclass(repr=False)
+class GlossaryTerm(Concept):
+    """
+    A defined term in a controlled vocabulary or glossary. Maps to schema:DefinedTerm and skos:Concept.
+    """
+    _inherited_slots: ClassVar[list[str]] = []
+
+    class_class_uri: ClassVar[URIRef] = SCHEMA["DefinedTerm"]
+    class_class_curie: ClassVar[str] = "schema:DefinedTerm"
+    class_name: ClassVar[str] = "GlossaryTerm"
+    class_model_uri: ClassVar[URIRef] = LOKF.GlossaryTerm
+
+    id: Union[str, GlossaryTermId] = None
+    type: str = None
+    definition: Optional[str] = None
+    abbreviation: Optional[str] = None
+
+    def __post_init__(self, *_: str, **kwargs: Any):
+        if self._is_empty(self.id):
+            self.MissingRequiredField("id")
+        if not isinstance(self.id, GlossaryTermId):
+            self.id = GlossaryTermId(self.id)
+
+        if self.definition is not None and not isinstance(self.definition, str):
+            self.definition = str(self.definition)
+
+        if self.abbreviation is not None and not isinstance(self.abbreviation, str):
+            self.abbreviation = str(self.abbreviation)
+
+        super().__post_init__(**kwargs)
+        if self._is_empty(self.type):
+            self.MissingRequiredField("type")
+        self.type = str(self.class_name)
+
+
+@dataclass(repr=False)
+class Reference(Concept):
+    """
+    A concept that mirrors an external source (a page, paper, or document) as a first-class citizen of the bundle so
+    it can be cited and linked.
+    """
+    _inherited_slots: ClassVar[list[str]] = []
+
+    class_class_uri: ClassVar[URIRef] = LOKF["Reference"]
+    class_class_curie: ClassVar[str] = "lokf:Reference"
+    class_name: ClassVar[str] = "Reference"
+    class_model_uri: ClassVar[URIRef] = LOKF.Reference
+
+    id: Union[str, ReferenceId] = None
+    type: str = None
+
+    def __post_init__(self, *_: str, **kwargs: Any):
+        if self._is_empty(self.id):
+            self.MissingRequiredField("id")
+        if not isinstance(self.id, ReferenceId):
+            self.id = ReferenceId(self.id)
+
+        super().__post_init__(**kwargs)
+        if self._is_empty(self.type):
+            self.MissingRequiredField("type")
+        self.type = str(self.class_name)
+
+
+@dataclass(repr=False)
+class Document(Concept):
+    """
+    A general knowledge document that does not fit a more specific type.
+    """
+    _inherited_slots: ClassVar[list[str]] = []
+
+    class_class_uri: ClassVar[URIRef] = LOKF["Document"]
+    class_class_curie: ClassVar[str] = "lokf:Document"
+    class_name: ClassVar[str] = "Document"
+    class_model_uri: ClassVar[URIRef] = LOKF.Document
+
+    id: Union[str, DocumentId] = None
+    type: str = None
+
+    def __post_init__(self, *_: str, **kwargs: Any):
+        if self._is_empty(self.id):
+            self.MissingRequiredField("id")
+        if not isinstance(self.id, DocumentId):
+            self.id = DocumentId(self.id)
+
+        super().__post_init__(**kwargs)
+        if self._is_empty(self.type):
+            self.MissingRequiredField("type")
+        self.type = str(self.class_name)
+
+
+@dataclass(repr=False)
+class Role(Concept):
+    """
+    A role an agent holds within an organization over a period of time — a job, appointment, or position. Reifies the
+    agent–organization link so it can carry a title (roleName) and a start/end interval, following the schema.org Role
+    and W3C ORG Membership patterns.
+    """
+    _inherited_slots: ClassVar[list[str]] = []
+
+    class_class_uri: ClassVar[URIRef] = SCHEMA["OrganizationRole"]
+    class_class_curie: ClassVar[str] = "schema:OrganizationRole"
+    class_name: ClassVar[str] = "Role"
+    class_model_uri: ClassVar[URIRef] = LOKF.Role
+
+    id: Union[str, RoleId] = None
+    type: str = None
+    roleName: Optional[str] = None
+    startDate: Optional[str] = None
+    endDate: Optional[str] = None
+    memberOf: Optional[Union[Union[str, ConceptId], list[Union[str, ConceptId]]]] = empty_list()
+    holder: Optional[Union[Union[str, ConceptId], list[Union[str, ConceptId]]]] = empty_list()
+
+    def __post_init__(self, *_: str, **kwargs: Any):
+        if self._is_empty(self.id):
+            self.MissingRequiredField("id")
+        if not isinstance(self.id, RoleId):
+            self.id = RoleId(self.id)
+
+        if self.roleName is not None and not isinstance(self.roleName, str):
+            self.roleName = str(self.roleName)
+
+        if self.startDate is not None and not isinstance(self.startDate, str):
+            self.startDate = str(self.startDate)
+
+        if self.endDate is not None and not isinstance(self.endDate, str):
+            self.endDate = str(self.endDate)
+
+        if not isinstance(self.memberOf, list):
+            self.memberOf = [self.memberOf] if self.memberOf is not None else []
+        self.memberOf = [v if isinstance(v, ConceptId) else ConceptId(v) for v in self.memberOf]
+
+        if not isinstance(self.holder, list):
+            self.holder = [self.holder] if self.holder is not None else []
+        self.holder = [v if isinstance(v, ConceptId) else ConceptId(v) for v in self.holder]
+
+        super().__post_init__(**kwargs)
+        if self._is_empty(self.type):
+            self.MissingRequiredField("type")
+        self.type = str(self.class_name)
+
+
+@dataclass(repr=False)
+class Agent(YAMLRoot):
+    """
+    A person or organization responsible for a concept.
+    """
+    _inherited_slots: ClassVar[list[str]] = []
+
+    class_class_uri: ClassVar[URIRef] = PROV["Agent"]
+    class_class_curie: ClassVar[str] = "prov:Agent"
+    class_name: ClassVar[str] = "Agent"
+    class_model_uri: ClassVar[URIRef] = LOKF.Agent
+
+    id: Union[str, AgentId] = None
+    type: str = None
+    name: Optional[str] = None
+    email: Optional[str] = None
+
+    def __post_init__(self, *_: str, **kwargs: Any):
+        if self._is_empty(self.type):
+            self.MissingRequiredField("type")
+        self.type = str(self.class_name)
+
+        if self._is_empty(self.id):
+            self.MissingRequiredField("id")
+        if not isinstance(self.id, AgentId):
+            self.id = AgentId(self.id)
+
+        if self.name is not None and not isinstance(self.name, str):
+            self.name = str(self.name)
+
+        if self.email is not None and not isinstance(self.email, str):
+            self.email = str(self.email)
+
+        super().__post_init__(**kwargs)
+
+
+    def __new__(cls, *args, **kwargs):
+
+        type_designator = "type"
+        if not type_designator in kwargs:
+            return super().__new__(cls,*args,**kwargs)
+        else:
+            type_designator_value = kwargs[type_designator]
+            target_cls = cls._class_for("class_name", type_designator_value)
+
+
+            if target_cls is None:
+                raise ValueError(f"Wrong type designator value: class {cls.__name__} "
+                                 f"has no subclass with ['class_name']='{kwargs[type_designator]}'")
+            return super().__new__(target_cls,*args,**kwargs)
+
+
+
+@dataclass(repr=False)
+class Person(Agent):
+    """
+    An individual person. Usable both as an inline Agent value (author, publisher) and as a standalone Concept
+    document with a body and typed relations.
+    """
+    _inherited_slots: ClassVar[list[str]] = []
+
+    class_class_uri: ClassVar[URIRef] = SCHEMA["Person"]
+    class_class_curie: ClassVar[str] = "schema:Person"
+    class_name: ClassVar[str] = "Person"
+    class_model_uri: ClassVar[URIRef] = LOKF.Person
+
+    id: Union[str, PersonId] = None
+    type: str = None
+    title: Optional[str] = None
+    description: Optional[str] = None
+    resource: Optional[Union[str, URIorCURIE]] = None
+    tags: Optional[Union[str, list[str]]] = empty_list()
+    timestamp: Optional[Union[str, XSDDateTime]] = None
+    created: Optional[Union[str, XSDDateTime]] = None
+    version: Optional[str] = None
+    license: Optional[Union[str, URIorCURIE]] = None
+    author: Optional[Union[dict[Union[str, AgentId], Union[dict, Agent]], list[Union[dict, Agent]]]] = empty_dict()
+    body: Optional[str] = None
+    citations: Optional[Union[Union[dict, "Citation"], list[Union[dict, "Citation"]]]] = empty_list()
+    relations: Optional[Union[Union[dict, "Relation"], list[Union[dict, "Relation"]]]] = empty_list()
+    isPartOf: Optional[Union[Union[str, ConceptId], list[Union[str, ConceptId]]]] = empty_list()
+    hasPart: Optional[Union[Union[str, ConceptId], list[Union[str, ConceptId]]]] = empty_list()
+    references: Optional[Union[Union[str, ConceptId], list[Union[str, ConceptId]]]] = empty_list()
+    dependsOn: Optional[Union[Union[str, ConceptId], list[Union[str, ConceptId]]]] = empty_list()
+    derivedFrom: Optional[Union[Union[str, ConceptId], list[Union[str, ConceptId]]]] = empty_list()
+    about: Optional[Union[Union[str, ConceptId], list[Union[str, ConceptId]]]] = empty_list()
+    sameAs: Optional[Union[Union[str, ConceptId], list[Union[str, ConceptId]]]] = empty_list()
+    relatedTo: Optional[Union[Union[str, ConceptId], list[Union[str, ConceptId]]]] = empty_list()
+    definedBy: Optional[Union[Union[str, ConceptId], list[Union[str, ConceptId]]]] = empty_list()
+    source: Optional[Union[Union[str, ConceptId], list[Union[str, ConceptId]]]] = empty_list()
+
+    def __post_init__(self, *_: str, **kwargs: Any):
+        if self._is_empty(self.id):
+            self.MissingRequiredField("id")
+        if not isinstance(self.id, PersonId):
+            self.id = PersonId(self.id)
+
+        if self._is_empty(self.type):
+            self.MissingRequiredField("type")
+        self.type = str(self.class_name)
+
+        if self.title is not None and not isinstance(self.title, str):
+            self.title = str(self.title)
+
+        if self.description is not None and not isinstance(self.description, str):
+            self.description = str(self.description)
+
+        if self.resource is not None and not isinstance(self.resource, URIorCURIE):
+            self.resource = URIorCURIE(self.resource)
+
+        if not isinstance(self.tags, list):
+            self.tags = [self.tags] if self.tags is not None else []
+        self.tags = [v if isinstance(v, str) else str(v) for v in self.tags]
+
+        if self.timestamp is not None and not isinstance(self.timestamp, XSDDateTime):
+            self.timestamp = XSDDateTime(self.timestamp)
+
+        if self.created is not None and not isinstance(self.created, XSDDateTime):
+            self.created = XSDDateTime(self.created)
+
+        if self.version is not None and not isinstance(self.version, str):
+            self.version = str(self.version)
+
+        if self.license is not None and not isinstance(self.license, URIorCURIE):
+            self.license = URIorCURIE(self.license)
+
+        self._normalize_inlined_as_list(slot_name="author", slot_type=Agent, key_name="id", keyed=True)
+
+        if self.body is not None and not isinstance(self.body, str):
+            self.body = str(self.body)
+
+        if not isinstance(self.citations, list):
+            self.citations = [self.citations] if self.citations is not None else []
+        self.citations = [v if isinstance(v, Citation) else Citation(**as_dict(v)) for v in self.citations]
+
+        self._normalize_inlined_as_list(slot_name="relations", slot_type=Relation, key_name="predicate", keyed=False)
+
+        if not isinstance(self.isPartOf, list):
+            self.isPartOf = [self.isPartOf] if self.isPartOf is not None else []
+        self.isPartOf = [v if isinstance(v, ConceptId) else ConceptId(v) for v in self.isPartOf]
+
+        if not isinstance(self.hasPart, list):
+            self.hasPart = [self.hasPart] if self.hasPart is not None else []
+        self.hasPart = [v if isinstance(v, ConceptId) else ConceptId(v) for v in self.hasPart]
+
+        if not isinstance(self.references, list):
+            self.references = [self.references] if self.references is not None else []
+        self.references = [v if isinstance(v, ConceptId) else ConceptId(v) for v in self.references]
+
+        if not isinstance(self.dependsOn, list):
+            self.dependsOn = [self.dependsOn] if self.dependsOn is not None else []
+        self.dependsOn = [v if isinstance(v, ConceptId) else ConceptId(v) for v in self.dependsOn]
+
+        if not isinstance(self.derivedFrom, list):
+            self.derivedFrom = [self.derivedFrom] if self.derivedFrom is not None else []
+        self.derivedFrom = [v if isinstance(v, ConceptId) else ConceptId(v) for v in self.derivedFrom]
+
+        if not isinstance(self.about, list):
+            self.about = [self.about] if self.about is not None else []
+        self.about = [v if isinstance(v, ConceptId) else ConceptId(v) for v in self.about]
+
+        if not isinstance(self.sameAs, list):
+            self.sameAs = [self.sameAs] if self.sameAs is not None else []
+        self.sameAs = [v if isinstance(v, ConceptId) else ConceptId(v) for v in self.sameAs]
+
+        if not isinstance(self.relatedTo, list):
+            self.relatedTo = [self.relatedTo] if self.relatedTo is not None else []
+        self.relatedTo = [v if isinstance(v, ConceptId) else ConceptId(v) for v in self.relatedTo]
+
+        if not isinstance(self.definedBy, list):
+            self.definedBy = [self.definedBy] if self.definedBy is not None else []
+        self.definedBy = [v if isinstance(v, ConceptId) else ConceptId(v) for v in self.definedBy]
+
+        if not isinstance(self.source, list):
+            self.source = [self.source] if self.source is not None else []
+        self.source = [v if isinstance(v, ConceptId) else ConceptId(v) for v in self.source]
+
+        super().__post_init__(**kwargs)
+
+
+@dataclass(repr=False)
+class Organization(Agent):
+    """
+    An organization, team, or group. Usable both as an inline Agent value (publisher) and as a standalone Concept
+    document with a body and typed relations.
+    """
+    _inherited_slots: ClassVar[list[str]] = []
+
+    class_class_uri: ClassVar[URIRef] = SCHEMA["Organization"]
+    class_class_curie: ClassVar[str] = "schema:Organization"
+    class_name: ClassVar[str] = "Organization"
+    class_model_uri: ClassVar[URIRef] = LOKF.Organization
+
+    id: Union[str, OrganizationId] = None
+    type: str = None
+    title: Optional[str] = None
+    description: Optional[str] = None
+    resource: Optional[Union[str, URIorCURIE]] = None
+    tags: Optional[Union[str, list[str]]] = empty_list()
+    timestamp: Optional[Union[str, XSDDateTime]] = None
+    created: Optional[Union[str, XSDDateTime]] = None
+    version: Optional[str] = None
+    license: Optional[Union[str, URIorCURIE]] = None
+    author: Optional[Union[dict[Union[str, AgentId], Union[dict, Agent]], list[Union[dict, Agent]]]] = empty_dict()
+    body: Optional[str] = None
+    citations: Optional[Union[Union[dict, "Citation"], list[Union[dict, "Citation"]]]] = empty_list()
+    relations: Optional[Union[Union[dict, "Relation"], list[Union[dict, "Relation"]]]] = empty_list()
+    isPartOf: Optional[Union[Union[str, ConceptId], list[Union[str, ConceptId]]]] = empty_list()
+    hasPart: Optional[Union[Union[str, ConceptId], list[Union[str, ConceptId]]]] = empty_list()
+    references: Optional[Union[Union[str, ConceptId], list[Union[str, ConceptId]]]] = empty_list()
+    dependsOn: Optional[Union[Union[str, ConceptId], list[Union[str, ConceptId]]]] = empty_list()
+    derivedFrom: Optional[Union[Union[str, ConceptId], list[Union[str, ConceptId]]]] = empty_list()
+    about: Optional[Union[Union[str, ConceptId], list[Union[str, ConceptId]]]] = empty_list()
+    sameAs: Optional[Union[Union[str, ConceptId], list[Union[str, ConceptId]]]] = empty_list()
+    relatedTo: Optional[Union[Union[str, ConceptId], list[Union[str, ConceptId]]]] = empty_list()
+    definedBy: Optional[Union[Union[str, ConceptId], list[Union[str, ConceptId]]]] = empty_list()
+    source: Optional[Union[Union[str, ConceptId], list[Union[str, ConceptId]]]] = empty_list()
+
+    def __post_init__(self, *_: str, **kwargs: Any):
+        if self._is_empty(self.id):
+            self.MissingRequiredField("id")
+        if not isinstance(self.id, OrganizationId):
+            self.id = OrganizationId(self.id)
+
+        if self._is_empty(self.type):
+            self.MissingRequiredField("type")
+        self.type = str(self.class_name)
+
+        if self.title is not None and not isinstance(self.title, str):
+            self.title = str(self.title)
+
+        if self.description is not None and not isinstance(self.description, str):
+            self.description = str(self.description)
+
+        if self.resource is not None and not isinstance(self.resource, URIorCURIE):
+            self.resource = URIorCURIE(self.resource)
+
+        if not isinstance(self.tags, list):
+            self.tags = [self.tags] if self.tags is not None else []
+        self.tags = [v if isinstance(v, str) else str(v) for v in self.tags]
+
+        if self.timestamp is not None and not isinstance(self.timestamp, XSDDateTime):
+            self.timestamp = XSDDateTime(self.timestamp)
+
+        if self.created is not None and not isinstance(self.created, XSDDateTime):
+            self.created = XSDDateTime(self.created)
+
+        if self.version is not None and not isinstance(self.version, str):
+            self.version = str(self.version)
+
+        if self.license is not None and not isinstance(self.license, URIorCURIE):
+            self.license = URIorCURIE(self.license)
+
+        self._normalize_inlined_as_list(slot_name="author", slot_type=Agent, key_name="id", keyed=True)
+
+        if self.body is not None and not isinstance(self.body, str):
+            self.body = str(self.body)
+
+        if not isinstance(self.citations, list):
+            self.citations = [self.citations] if self.citations is not None else []
+        self.citations = [v if isinstance(v, Citation) else Citation(**as_dict(v)) for v in self.citations]
+
+        self._normalize_inlined_as_list(slot_name="relations", slot_type=Relation, key_name="predicate", keyed=False)
+
+        if not isinstance(self.isPartOf, list):
+            self.isPartOf = [self.isPartOf] if self.isPartOf is not None else []
+        self.isPartOf = [v if isinstance(v, ConceptId) else ConceptId(v) for v in self.isPartOf]
+
+        if not isinstance(self.hasPart, list):
+            self.hasPart = [self.hasPart] if self.hasPart is not None else []
+        self.hasPart = [v if isinstance(v, ConceptId) else ConceptId(v) for v in self.hasPart]
+
+        if not isinstance(self.references, list):
+            self.references = [self.references] if self.references is not None else []
+        self.references = [v if isinstance(v, ConceptId) else ConceptId(v) for v in self.references]
+
+        if not isinstance(self.dependsOn, list):
+            self.dependsOn = [self.dependsOn] if self.dependsOn is not None else []
+        self.dependsOn = [v if isinstance(v, ConceptId) else ConceptId(v) for v in self.dependsOn]
+
+        if not isinstance(self.derivedFrom, list):
+            self.derivedFrom = [self.derivedFrom] if self.derivedFrom is not None else []
+        self.derivedFrom = [v if isinstance(v, ConceptId) else ConceptId(v) for v in self.derivedFrom]
+
+        if not isinstance(self.about, list):
+            self.about = [self.about] if self.about is not None else []
+        self.about = [v if isinstance(v, ConceptId) else ConceptId(v) for v in self.about]
+
+        if not isinstance(self.sameAs, list):
+            self.sameAs = [self.sameAs] if self.sameAs is not None else []
+        self.sameAs = [v if isinstance(v, ConceptId) else ConceptId(v) for v in self.sameAs]
+
+        if not isinstance(self.relatedTo, list):
+            self.relatedTo = [self.relatedTo] if self.relatedTo is not None else []
+        self.relatedTo = [v if isinstance(v, ConceptId) else ConceptId(v) for v in self.relatedTo]
+
+        if not isinstance(self.definedBy, list):
+            self.definedBy = [self.definedBy] if self.definedBy is not None else []
+        self.definedBy = [v if isinstance(v, ConceptId) else ConceptId(v) for v in self.definedBy]
+
+        if not isinstance(self.source, list):
+            self.source = [self.source] if self.source is not None else []
+        self.source = [v if isinstance(v, ConceptId) else ConceptId(v) for v in self.source]
+
+        super().__post_init__(**kwargs)
+
+
+@dataclass(repr=False)
+class Field(YAMLRoot):
+    """
+    A single column / property within a Table or Dataset schema. Maps to schema:PropertyValue.
+    """
+    _inherited_slots: ClassVar[list[str]] = []
+
+    class_class_uri: ClassVar[URIRef] = SCHEMA["PropertyValue"]
+    class_class_curie: ClassVar[str] = "schema:PropertyValue"
+    class_name: ClassVar[str] = "Field"
+    class_model_uri: ClassVar[URIRef] = LOKF.Field
+
+    name: Optional[str] = None
+    datatype: Optional[Union[str, "FieldType"]] = None
+    description: Optional[str] = None
+    unit: Optional[str] = None
+    is_key: Optional[Union[bool, Bool]] = None
+    constraints: Optional[str] = None
+
+    def __post_init__(self, *_: str, **kwargs: Any):
+        if self.name is not None and not isinstance(self.name, str):
+            self.name = str(self.name)
+
+        if self.datatype is not None and not isinstance(self.datatype, FieldType):
+            self.datatype = FieldType(self.datatype)
+
+        if self.description is not None and not isinstance(self.description, str):
+            self.description = str(self.description)
+
+        if self.unit is not None and not isinstance(self.unit, str):
+            self.unit = str(self.unit)
+
+        if self.is_key is not None and not isinstance(self.is_key, Bool):
+            self.is_key = Bool(self.is_key)
+
+        if self.constraints is not None and not isinstance(self.constraints, str):
+            self.constraints = str(self.constraints)
+
+        super().__post_init__(**kwargs)
+
+
+@dataclass(repr=False)
+class Distribution(YAMLRoot):
+    """
+    A specific accessible form of a Dataset (a file, feed, or endpoint). Maps to dcat:Distribution.
+    """
+    _inherited_slots: ClassVar[list[str]] = []
+
+    class_class_uri: ClassVar[URIRef] = DCAT["Distribution"]
+    class_class_curie: ClassVar[str] = "dcat:Distribution"
+    class_name: ClassVar[str] = "Distribution"
+    class_model_uri: ClassVar[URIRef] = LOKF.Distribution
+
+    name: Optional[str] = None
+    description: Optional[str] = None
+    access_url: Optional[Union[str, URIorCURIE]] = None
+    media_type: Optional[str] = None
+
+    def __post_init__(self, *_: str, **kwargs: Any):
+        if self.name is not None and not isinstance(self.name, str):
+            self.name = str(self.name)
+
+        if self.description is not None and not isinstance(self.description, str):
+            self.description = str(self.description)
+
+        if self.access_url is not None and not isinstance(self.access_url, URIorCURIE):
+            self.access_url = URIorCURIE(self.access_url)
+
+        if self.media_type is not None and not isinstance(self.media_type, str):
+            self.media_type = str(self.media_type)
+
+        super().__post_init__(**kwargs)
+
+
+@dataclass(repr=False)
+class Relation(YAMLRoot):
+    """
+    A typed, reified relationship from the containing concept to a target, used when a predicate is not covered by one
+    of the named relation slots. Modeled as an rdf:Statement (subject = the containing concept).
+    """
+    _inherited_slots: ClassVar[list[str]] = []
+
+    class_class_uri: ClassVar[URIRef] = RDF["Statement"]
+    class_class_curie: ClassVar[str] = "rdf:Statement"
+    class_name: ClassVar[str] = "Relation"
+    class_model_uri: ClassVar[URIRef] = LOKF.Relation
+
+    predicate: Union[str, "RelationType"] = None
+    target: Union[str, ConceptId] = None
+    relation_label: Optional[str] = None
+
+    def __post_init__(self, *_: str, **kwargs: Any):
+        if self._is_empty(self.predicate):
+            self.MissingRequiredField("predicate")
+        if not isinstance(self.predicate, RelationType):
+            self.predicate = RelationType(self.predicate)
+
+        if self._is_empty(self.target):
+            self.MissingRequiredField("target")
+        if not isinstance(self.target, ConceptId):
+            self.target = ConceptId(self.target)
+
+        if self.relation_label is not None and not isinstance(self.relation_label, str):
+            self.relation_label = str(self.relation_label)
+
+        super().__post_init__(**kwargs)
+
+
+@dataclass(repr=False)
+class Citation(YAMLRoot):
+    """
+    A reference to an external source supporting a claim in a concept's body. Attached via the schema:citation
+    predicate.
+    """
+    _inherited_slots: ClassVar[list[str]] = []
+
+    class_class_uri: ClassVar[URIRef] = SCHEMA["CreativeWork"]
+    class_class_curie: ClassVar[str] = "schema:CreativeWork"
+    class_name: ClassVar[str] = "Citation"
+    class_model_uri: ClassVar[URIRef] = LOKF.Citation
+
+    title: Optional[str] = None
+    url: Optional[Union[str, URIorCURIE]] = None
+    description: Optional[str] = None
+
+    def __post_init__(self, *_: str, **kwargs: Any):
+        if self.title is not None and not isinstance(self.title, str):
+            self.title = str(self.title)
+
+        if self.url is not None and not isinstance(self.url, URIorCURIE):
+            self.url = URIorCURIE(self.url)
+
+        if self.description is not None and not isinstance(self.description, str):
+            self.description = str(self.description)
+
+        super().__post_init__(**kwargs)
+
+
+# Enumerations
+class RelationType(EnumDefinitionImpl):
+    """
+    The recommended controlled vocabulary of relationship predicates for reified Relations. Each value carries a
+    `meaning` mapping to its RDF predicate in schema.org, Dublin Core Terms, PROV-O, RDFS, or OWL.
+    """
+    isPartOf = PermissibleValue(
+        text="isPartOf",
+        description="The concept is a part of the target.",
+        meaning=DCTERMS["isPartOf"])
+    hasPart = PermissibleValue(
+        text="hasPart",
+        description="The target is a part of the concept.",
+        meaning=SCHEMA["hasPart"])
+    references = PermissibleValue(
+        text="references",
+        description="The concept refers to the target.",
+        meaning=DCTERMS["references"])
+    dependsOn = PermissibleValue(
+        text="dependsOn",
+        description="The concept depends on the target.",
+        meaning=DCTERMS["requires"])
+    derivedFrom = PermissibleValue(
+        text="derivedFrom",
+        description="The concept was derived from the target.",
+        meaning=PROV["wasDerivedFrom"])
+    about = PermissibleValue(
+        text="about",
+        description="The concept is about the target.",
+        meaning=SCHEMA["about"])
+    sameAs = PermissibleValue(
+        text="sameAs",
+        description="The concept is the same entity as the target.",
+        meaning=OWL["sameAs"])
+    relatedTo = PermissibleValue(
+        text="relatedTo",
+        description="The concept is generically related to the target.",
+        meaning=DCTERMS["relation"])
+    wasAttributedTo = PermissibleValue(
+        text="wasAttributedTo",
+        description="The concept was attributed to the target agent.",
+        meaning=PROV["wasAttributedTo"])
+    definedBy = PermissibleValue(
+        text="definedBy",
+        description="The concept is formally defined by the target.",
+        meaning=RDFS["isDefinedBy"])
+    measures = PermissibleValue(
+        text="measures",
+        description="The concept (a metric) measures the target.",
+        meaning=LOKF["measures"])
+    joinsWith = PermissibleValue(
+        text="joinsWith",
+        description="The concept (a table) is joined with the target.",
+        meaning=LOKF["joinsWith"])
+    source = PermissibleValue(
+        text="source",
+        description="The concept is sourced from the target.",
+        meaning=DCTERMS["source"])
+    memberOf = PermissibleValue(
+        text="memberOf",
+        description="The concept (a role) is held within the target organization.",
+        meaning=SCHEMA["memberOf"])
+    holder = PermissibleValue(
+        text="holder",
+        description="The target agent holds this concept (a role).",
+        meaning=ORG["member"])
+
+    _defn = EnumDefinition(
+        name="RelationType",
+        description="""The recommended controlled vocabulary of relationship predicates for reified Relations. Each value carries a `meaning` mapping to its RDF predicate in schema.org, Dublin Core Terms, PROV-O, RDFS, or OWL.""",
+    )
+
+class FieldType(EnumDefinitionImpl):
+    """
+    Datatypes for dataset/table fields, each mapped to its XSD (or RDF) type.
+    """
+    string = PermissibleValue(
+        text="string",
+        meaning=XSD["string"])
+    integer = PermissibleValue(
+        text="integer",
+        meaning=XSD["integer"])
+    number = PermissibleValue(
+        text="number",
+        meaning=XSD["decimal"])
+    boolean = PermissibleValue(
+        text="boolean",
+        meaning=XSD["boolean"])
+    date = PermissibleValue(
+        text="date",
+        meaning=XSD["date"])
+    datetime = PermissibleValue(
+        text="datetime",
+        meaning=XSD["dateTime"])
+    time = PermissibleValue(
+        text="time",
+        meaning=XSD["time"])
+    uri = PermissibleValue(
+        text="uri",
+        meaning=XSD["anyURI"])
+    json = PermissibleValue(
+        text="json",
+        meaning=RDF["JSON"])
+
+    _defn = EnumDefinition(
+        name="FieldType",
+        description="Datatypes for dataset/table fields, each mapped to its XSD (or RDF) type.",
+    )
+
+# Slots
+class slots:
+    pass
+
+slots.id = Slot(uri=SCHEMA.identifier, name="id", curie=SCHEMA.curie('identifier'),
+                   model_uri=LOKF.id, domain=None, range=URIRef)
+
+slots.type = Slot(uri=LOKF.type, name="type", curie=LOKF.curie('type'),
+                   model_uri=LOKF.type, domain=None, range=str)
+
+slots.title = Slot(uri=SCHEMA.name, name="title", curie=SCHEMA.curie('name'),
+                   model_uri=LOKF.title, domain=None, range=Optional[str])
+
+slots.description = Slot(uri=SCHEMA.description, name="description", curie=SCHEMA.curie('description'),
+                   model_uri=LOKF.description, domain=None, range=Optional[str])
+
+slots.resource = Slot(uri=SCHEMA.url, name="resource", curie=SCHEMA.curie('url'),
+                   model_uri=LOKF.resource, domain=None, range=Optional[Union[str, URIorCURIE]])
+
+slots.tags = Slot(uri=SCHEMA.keywords, name="tags", curie=SCHEMA.curie('keywords'),
+                   model_uri=LOKF.tags, domain=None, range=Optional[Union[str, list[str]]])
+
+slots.timestamp = Slot(uri=SCHEMA.dateModified, name="timestamp", curie=SCHEMA.curie('dateModified'),
+                   model_uri=LOKF.timestamp, domain=None, range=Optional[Union[str, XSDDateTime]])
+
+slots.created = Slot(uri=SCHEMA.dateCreated, name="created", curie=SCHEMA.curie('dateCreated'),
+                   model_uri=LOKF.created, domain=None, range=Optional[Union[str, XSDDateTime]])
+
+slots.version = Slot(uri=SCHEMA.version, name="version", curie=SCHEMA.curie('version'),
+                   model_uri=LOKF.version, domain=None, range=Optional[str])
+
+slots.license = Slot(uri=SCHEMA.license, name="license", curie=SCHEMA.curie('license'),
+                   model_uri=LOKF.license, domain=None, range=Optional[Union[str, URIorCURIE]])
+
+slots.author = Slot(uri=SCHEMA.author, name="author", curie=SCHEMA.curie('author'),
+                   model_uri=LOKF.author, domain=None, range=Optional[Union[dict[Union[str, AgentId], Union[dict, Agent]], list[Union[dict, Agent]]]])
+
+slots.publisher = Slot(uri=SCHEMA.publisher, name="publisher", curie=SCHEMA.curie('publisher'),
+                   model_uri=LOKF.publisher, domain=None, range=Optional[Union[dict, Agent]])
+
+slots.body = Slot(uri=SCHEMA.text, name="body", curie=SCHEMA.curie('text'),
+                   model_uri=LOKF.body, domain=None, range=Optional[str])
+
+slots.citations = Slot(uri=SCHEMA.citation, name="citations", curie=SCHEMA.curie('citation'),
+                   model_uri=LOKF.citations, domain=None, range=Optional[Union[Union[dict, Citation], list[Union[dict, Citation]]]])
+
+slots.concepts = Slot(uri=DCAT.dataset, name="concepts", curie=DCAT.curie('dataset'),
+                   model_uri=LOKF.concepts, domain=None, range=Optional[Union[dict[Union[str, ConceptId], Union[dict, Concept]], list[Union[dict, Concept]]]])
+
+slots.relations = Slot(uri=LOKF.relations, name="relations", curie=LOKF.curie('relations'),
+                   model_uri=LOKF.relations, domain=None, range=Optional[Union[Union[dict, Relation], list[Union[dict, Relation]]]])
+
+slots.isPartOf = Slot(uri=DCTERMS.isPartOf, name="isPartOf", curie=DCTERMS.curie('isPartOf'),
+                   model_uri=LOKF.isPartOf, domain=None, range=Optional[Union[Union[str, ConceptId], list[Union[str, ConceptId]]]])
+
+slots.hasPart = Slot(uri=SCHEMA.hasPart, name="hasPart", curie=SCHEMA.curie('hasPart'),
+                   model_uri=LOKF.hasPart, domain=None, range=Optional[Union[Union[str, ConceptId], list[Union[str, ConceptId]]]])
+
+slots.references = Slot(uri=DCTERMS.references, name="references", curie=DCTERMS.curie('references'),
+                   model_uri=LOKF.references, domain=None, range=Optional[Union[Union[str, ConceptId], list[Union[str, ConceptId]]]])
+
+slots.dependsOn = Slot(uri=DCTERMS.requires, name="dependsOn", curie=DCTERMS.curie('requires'),
+                   model_uri=LOKF.dependsOn, domain=None, range=Optional[Union[Union[str, ConceptId], list[Union[str, ConceptId]]]])
+
+slots.derivedFrom = Slot(uri=PROV.wasDerivedFrom, name="derivedFrom", curie=PROV.curie('wasDerivedFrom'),
+                   model_uri=LOKF.derivedFrom, domain=None, range=Optional[Union[Union[str, ConceptId], list[Union[str, ConceptId]]]])
+
+slots.about = Slot(uri=SCHEMA.about, name="about", curie=SCHEMA.curie('about'),
+                   model_uri=LOKF.about, domain=None, range=Optional[Union[Union[str, ConceptId], list[Union[str, ConceptId]]]])
+
+slots.sameAs = Slot(uri=SCHEMA.sameAs, name="sameAs", curie=SCHEMA.curie('sameAs'),
+                   model_uri=LOKF.sameAs, domain=None, range=Optional[Union[Union[str, ConceptId], list[Union[str, ConceptId]]]])
+
+slots.relatedTo = Slot(uri=DCTERMS.relation, name="relatedTo", curie=DCTERMS.curie('relation'),
+                   model_uri=LOKF.relatedTo, domain=None, range=Optional[Union[Union[str, ConceptId], list[Union[str, ConceptId]]]])
+
+slots.definedBy = Slot(uri=RDFS.isDefinedBy, name="definedBy", curie=RDFS.curie('isDefinedBy'),
+                   model_uri=LOKF.definedBy, domain=None, range=Optional[Union[Union[str, ConceptId], list[Union[str, ConceptId]]]])
+
+slots.source = Slot(uri=DCTERMS.source, name="source", curie=DCTERMS.curie('source'),
+                   model_uri=LOKF.source, domain=None, range=Optional[Union[Union[str, ConceptId], list[Union[str, ConceptId]]]])
+
+slots.predicate = Slot(uri=RDF.predicate, name="predicate", curie=RDF.curie('predicate'),
+                   model_uri=LOKF.predicate, domain=None, range=Union[str, "RelationType"])
+
+slots.target = Slot(uri=RDF.object, name="target", curie=RDF.curie('object'),
+                   model_uri=LOKF.target, domain=None, range=Union[str, ConceptId])
+
+slots.relation_label = Slot(uri=RDFS.label, name="relation_label", curie=RDFS.curie('label'),
+                   model_uri=LOKF.relation_label, domain=None, range=Optional[str])
+
+slots.distribution = Slot(uri=DCAT.distribution, name="distribution", curie=DCAT.curie('distribution'),
+                   model_uri=LOKF.distribution, domain=None, range=Optional[Union[Union[dict, Distribution], list[Union[dict, Distribution]]]])
+
+slots.fields = Slot(uri=LOKF.field, name="fields", curie=LOKF.curie('field'),
+                   model_uri=LOKF.fields, domain=None, range=Optional[Union[Union[dict, Field], list[Union[dict, Field]]]])
+
+slots.name = Slot(uri=SCHEMA.name, name="name", curie=SCHEMA.curie('name'),
+                   model_uri=LOKF.name, domain=None, range=Optional[str])
+
+slots.email = Slot(uri=SCHEMA.email, name="email", curie=SCHEMA.curie('email'),
+                   model_uri=LOKF.email, domain=None, range=Optional[str])
+
+slots.datatype = Slot(uri=LOKF.datatype, name="datatype", curie=LOKF.curie('datatype'),
+                   model_uri=LOKF.datatype, domain=None, range=Optional[Union[str, "FieldType"]])
+
+slots.unit = Slot(uri=SCHEMA.unitText, name="unit", curie=SCHEMA.curie('unitText'),
+                   model_uri=LOKF.unit, domain=None, range=Optional[str])
+
+slots.is_key = Slot(uri=LOKF.isKey, name="is_key", curie=LOKF.curie('isKey'),
+                   model_uri=LOKF.is_key, domain=None, range=Optional[Union[bool, Bool]])
+
+slots.constraints = Slot(uri=LOKF.constraints, name="constraints", curie=LOKF.curie('constraints'),
+                   model_uri=LOKF.constraints, domain=None, range=Optional[str])
+
+slots.access_url = Slot(uri=DCAT.accessURL, name="access_url", curie=DCAT.curie('accessURL'),
+                   model_uri=LOKF.access_url, domain=None, range=Optional[Union[str, URIorCURIE]])
+
+slots.media_type = Slot(uri=DCAT.mediaType, name="media_type", curie=DCAT.curie('mediaType'),
+                   model_uri=LOKF.media_type, domain=None, range=Optional[str])
+
+slots.formula = Slot(uri=LOKF.formula, name="formula", curie=LOKF.curie('formula'),
+                   model_uri=LOKF.formula, domain=None, range=Optional[str])
+
+slots.measures = Slot(uri=LOKF.measures, name="measures", curie=LOKF.curie('measures'),
+                   model_uri=LOKF.measures, domain=None, range=Optional[Union[Union[str, ConceptId], list[Union[str, ConceptId]]]])
+
+slots.endpoint = Slot(uri=SCHEMA.url, name="endpoint", curie=SCHEMA.curie('url'),
+                   model_uri=LOKF.endpoint, domain=None, range=Optional[Union[str, URIorCURIE]])
+
+slots.http_method = Slot(uri=SCHEMA.httpMethod, name="http_method", curie=SCHEMA.curie('httpMethod'),
+                   model_uri=LOKF.http_method, domain=None, range=Optional[str])
+
+slots.documentation = Slot(uri=SCHEMA.documentation, name="documentation", curie=SCHEMA.curie('documentation'),
+                   model_uri=LOKF.documentation, domain=None, range=Optional[Union[str, URIorCURIE]])
+
+slots.definition = Slot(uri=SKOS.definition, name="definition", curie=SKOS.curie('definition'),
+                   model_uri=LOKF.definition, domain=None, range=Optional[str])
+
+slots.abbreviation = Slot(uri=SCHEMA.alternateName, name="abbreviation", curie=SCHEMA.curie('alternateName'),
+                   model_uri=LOKF.abbreviation, domain=None, range=Optional[str])
+
+slots.roleName = Slot(uri=SCHEMA.roleName, name="roleName", curie=SCHEMA.curie('roleName'),
+                   model_uri=LOKF.roleName, domain=None, range=Optional[str])
+
+slots.startDate = Slot(uri=SCHEMA.startDate, name="startDate", curie=SCHEMA.curie('startDate'),
+                   model_uri=LOKF.startDate, domain=None, range=Optional[str])
+
+slots.endDate = Slot(uri=SCHEMA.endDate, name="endDate", curie=SCHEMA.curie('endDate'),
+                   model_uri=LOKF.endDate, domain=None, range=Optional[str])
+
+slots.memberOf = Slot(uri=SCHEMA.memberOf, name="memberOf", curie=SCHEMA.curie('memberOf'),
+                   model_uri=LOKF.memberOf, domain=None, range=Optional[Union[Union[str, ConceptId], list[Union[str, ConceptId]]]])
+
+slots.holder = Slot(uri=ORG.member, name="holder", curie=ORG.curie('member'),
+                   model_uri=LOKF.holder, domain=None, range=Optional[Union[Union[str, ConceptId], list[Union[str, ConceptId]]]])
+
+slots.url = Slot(uri=SCHEMA.url, name="url", curie=SCHEMA.curie('url'),
+                   model_uri=LOKF.url, domain=None, range=Optional[Union[str, URIorCURIE]])
+
+slots.lokf_version = Slot(uri=LOKF.lokfVersion, name="lokf_version", curie=LOKF.curie('lokfVersion'),
+                   model_uri=LOKF.lokf_version, domain=None, range=Optional[str])
+
+slots.okf_version = Slot(uri=LOKF.okfVersion, name="okf_version", curie=LOKF.curie('okfVersion'),
+                   model_uri=LOKF.okf_version, domain=None, range=Optional[str])
+
+slots.base_iri = Slot(uri=LOKF.baseIri, name="base_iri", curie=LOKF.curie('baseIri'),
+                   model_uri=LOKF.base_iri, domain=None, range=Optional[Union[str, URI]])
+
+slots.context = Slot(uri=LOKF.context, name="context", curie=LOKF.curie('context'),
+                   model_uri=LOKF.context, domain=None, range=Optional[Union[str, URI]])
+

--- a/uv.lock
+++ b/uv.lock
@@ -834,6 +834,7 @@ name = "lokf"
 version = "0.1.0"
 source = { editable = "." }
 dependencies = [
+    { name = "linkml-runtime" },
     { name = "mcp" },
     { name = "pyoxigraph" },
     { name = "pyyaml" },
@@ -856,6 +857,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "linkml", marker = "extra == 'build'", specifier = ">=1.8.5" },
+    { name = "linkml-runtime", specifier = ">=1.8" },
     { name = "mcp", specifier = ">=1.2" },
     { name = "pyoxigraph", specifier = ">=0.4" },
     { name = "pyyaml", specifier = ">=6.0" },


### PR DESCRIPTION
**Phase 1 of 3** for the tabular-projection + scaffolder work.

Because LOKF is defined once in LinkML, a bundle projects **two** ways — the *literal* knowledge graph (RDF) and the *abstract* one: well-modeled, linked data you can put in tables. This wires the tabular side's foundations into `lokf-build`:

- **`gen-python` → `src/lokf/datamodel.py`** — typed **dataclass bindings**: `from lokf.datamodel import Metric`. Backed by `linkml_runtime`; validate required fields and round-trip to JSON / YAML / RDF.
- **`gen-sqltables` → `lokf.sql`** — the **relational schema**: one table per type, foreign keys auto-created for the typed relations (165 tables — every multivalued relation normalized into a link table).

`linkml_runtime` is added as a light core dependency (the runtime for the generated dataclasses); the heavy `linkml` generator stays in the `build` extra. The README is reframed around the two-projections idea.

### Note on the binding generator
`gen-pydantic` output trips a `pydantic` 2.13 forward-ref bug (`NameError: Callable`) in its generated `LinkMLMeta` / validator helpers, so those models can't be instantiated. The `gen-python` dataclasses instantiate cleanly, so those ship. (Easy to revisit if a future LinkML fixes the pydantic path.)

Build + **117 tests** green.

### Next (stacked PRs)
- **Phase 2** — `lokf.tables`: a bundle → linked DataFrames (one per type + a relations table), with writers for CSV/Parquet/SQL and `CREATE EXTERNAL TABLE` DDL for BigQuery/Athena, plus a `lokf tables` CLI.
- **Phase 3** — `lokf new` scaffolder + a `scaffold-knowledge-base` agent skill (idea → bundle → published site).