### PR TITLE
Release 0.2.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "lokf"
-version = "0.1.0"
+version = "0.2.0"
 description = "Linked Open Knowledge Format (LOKF) — a semantic profile of Google's Open Knowledge Format, defined once in LinkML"
 readme = "README.md"
 license = "CC-BY-4.0"

--- a/uv.lock
+++ b/uv.lock
@@ -833,7 +833,7 @@ wheels = [
 
 [[package]]
 name = "lokf"
-version = "0.1.0"
+version = "0.2.0"
 source = { editable = "." }
 dependencies = [
     { name = "linkml-runtime" },
@@ -2323,8 +2323,8 @@ name = "uvicorn"
 version = "0.49.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "click" },
-    { name = "h11" },
+    { name = "click", marker = "python_full_version >= '3.12' or sys_platform != 'emscripten'" },
+    { name = "h11", marker = "python_full_version >= '3.12' or sys_platform != 'emscripten'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/c4/1f/fa18009dea8469069cca78a4e877a008ab78f08b064bfc9ab891579077ff/uvicorn-0.49.0.tar.gz", hash = "sha256:ebf4271aa580d9de97f93192d4595176df6e91f9aae919ca73e4fc07df1e66a3", size = 91284, upload-time = "2026-06-03T22:01:30.448Z" }
 wheels = [


### PR DESCRIPTION
Bumps the version to **0.2.0** for the feature release. Publishing the `v0.2.0` GitHub Release after this merges triggers the Trusted-Publishing workflow (pytest gate → `uv build` → PyPI).

Since 0.1.0, all additive / non-breaking:
- **Two projections:** generated Python dataclass bindings (`lokf.datamodel`) + relational schema (`lokf.sql`), and `lokf.tables` — a bundle → linked DataFrames / Parquet / SQL, with BigQuery/Athena external-table DDL. New `lokf tables` CLI + `tables` extra.
- **`lokf new`** — scaffolds a knowledge-base repo with a full Astro site (concept pages, `/graph` browser, `graph.json`/`graph.jsonld`), a Pages workflow, and the bundled agent skills; plus a `scaffold-knowledge-base` skill.
- **Schema:** a `Role` type (schema.org `OrganizationRole` + W3C ORG) and `Person`/`Organization` as full concepts.
- Packaging: `linkml-runtime` added as a light runtime dep for the bindings; sdist trimmed (was leaking `web/node_modules`).

`uv build` verified locally: clean 384 KB sdist / 210 KB wheel (bindings + all 21 template files + 6 skills), 134 tests green.