### PR TITLE
Bump publish workflow actions off deprecated Node 20

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -17,8 +17,8 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v4
-      - uses: astral-sh/setup-uv@v5
+      - uses: actions/checkout@v5
+      - uses: astral-sh/setup-uv@v7
         with:
           enable-cache: true
 
@@ -28,7 +28,7 @@ jobs:
       - name: Build sdist + wheel
         run: uv build
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         with:
           name: dist
           path: dist/
@@ -42,7 +42,7 @@ jobs:
     permissions:
       id-token: write # OIDC token for Trusted Publishing
     steps:
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v8
         with:
           name: dist
           path: dist/


### PR DESCRIPTION
The PyPI publish workflow ran with Node-20 deprecation warnings. Bump the four flagged actions to the majors whose `action.yml` declares **node24** (verified via each tag's runtime — the naive next-major wasn't enough: `setup-uv@v6` and `artifact@v5` are still node20):

- `actions/checkout@v4` → **@v5**
- `astral-sh/setup-uv@v5` → **@v7**
- `actions/upload-artifact@v4` → **@v7**
- `actions/download-artifact@v4` → **@v8**

`upload@v7` / `download@v8` share the v4-era immutable-artifact backend, so they pair. `pypa/gh-action-pypi-publish@release/v1` wasn't flagged (moving tag, maintained). Workflow-only; publish runs only on release, so this doesn't re-trigger a publish.