### PR TITLE
Bump to 0.3.0 and guard release tag/version drift

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -22,6 +22,19 @@ jobs:
         with:
           enable-cache: true
 
+      # A release tag whose version was never bumped in pyproject.toml only
+      # surfaces at upload time, as an opaque PyPI "400 File already exists".
+      # Fail here instead, before the tests even run.
+      - name: Check the release tag matches the package version
+        if: github.event_name == 'release'
+        run: |
+          tag="${GITHUB_REF_NAME#v}"
+          packaged="$(uv version --short)"
+          if [ "$tag" != "$packaged" ]; then
+            echo "::error::Release tag v$tag does not match pyproject.toml version $packaged — bump the version, merge, then re-tag."
+            exit 1
+          fi
+
       - name: Test (gate the release)
         run: uv run --group dev pytest -q
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "lokf"
-version = "0.2.0"
+version = "0.3.0"
 description = "Linked Open Knowledge Format (LOKF) — a semantic profile of Google's Open Knowledge Format, defined once in LinkML"
 readme = "README.md"
 license = "CC-BY-4.0"

--- a/uv.lock
+++ b/uv.lock
@@ -833,7 +833,7 @@ wheels = [
 
 [[package]]
 name = "lokf"
-version = "0.2.0"
+version = "0.3.0"
 source = { editable = "." }
 dependencies = [
     { name = "linkml-runtime" },


### PR DESCRIPTION
## Why

The [v0.3.0 publish run](https://github.com/nicholsn/lokf/actions/runs/30293667529) failed. Tests and `uv build` passed, but the upload got:

```
400 File already exists ('lokf-0.2.0-py3-none-any.whl', ...)
```

`pyproject.toml` was never bumped before the v0.3.0 tag was cut, so `uv build` produced `lokf-0.2.0.*` and PyPI correctly refused to overwrite the existing 0.2.0 files. Nothing was wrong with the package itself.

## What

- Bump `0.2.0` → `0.3.0` (`pyproject.toml` + `uv.lock`, via `uv version 0.3.0`).
- Add a tag/version guard to the `build` job in `publish.yml`. On a `release` event it compares the tag (minus the `v`) to `uv version --short` and fails immediately on mismatch, so a missed bump reads as "bump the version, merge, then re-tag" instead of an opaque PyPI 400 two jobs later. Skipped on `workflow_dispatch`, which has no tag.

## Verification

- `uv run --group dev pytest -q` → 158 passed
- `uv build` → `lokf-0.3.0.tar.gz`, `lokf-0.3.0-py3-none-any.whl`
- `uvx twine check dist/*` → PASSED on both
- Guard logic exercised both ways: passes on `v0.3.0`, fails on a mismatched tag
- 0.3.0 confirmed unused on PyPI (published: 0.1.0, 0.2.0)

## After merge

The existing v0.3.0 tag/release point at the un-bumped commit, so they get deleted and recreated at the merge commit to retrigger publish.