### PR TITLE
Bump to 0.4.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "lokf"
-version = "0.3.0"
+version = "0.4.0"
 description = "Linked Open Knowledge Format (LOKF) — a semantic profile of Google's Open Knowledge Format, defined once in LinkML"
 readme = "README.md"
 license = "Apache-2.0"

--- a/src/lokf/data/lokf.yaml
+++ b/src/lokf/data/lokf.yaml
@@ -14,7 +14,7 @@ description: >-
   which the JSON-LD context, JSON Schema, SHACL shapes, and an OWL ontology
   are generated.
 license: https://creativecommons.org/licenses/by/4.0/
-version: 0.1.0
+version: 0.4.0
 
 # ---------------------------------------------------------------------------
 # Namespaces

--- a/uv.lock
+++ b/uv.lock
@@ -833,7 +833,7 @@ wheels = [
 
 [[package]]
 name = "lokf"
-version = "0.3.0"
+version = "0.4.0"
 source = { editable = "." }
 dependencies = [
     { name = "linkml-runtime" },


### PR DESCRIPTION
Release prep for **v0.4.0**.

- Bump the package version 0.3.0 → 0.4.0 (`pyproject.toml` + `uv.lock`).
- Sync the packaged schema copy `src/lokf/data/lokf.yaml` to the repo-root `lokf.yaml` (`version: 0.4.0`). The packaged copy had drifted (still read `0.1.0`) after #30 bumped the root schema, so `test_packaged_data_matches_root_files` — and therefore the release's pytest gate — was failing. Only the stale packaged copy is synced; the generated downstream artifacts (owl/shacl/sql/nt) are left as committed to avoid unrelated linkml regeneration churn.

After merge: the stale `v0.4.0` tag (currently on the diataxis merge, where the version was still 0.3.0) is moved onto this bump commit and a GitHub Release is cut, which fires `publish.yml` → PyPI Trusted Publishing.

159 tests pass.