### PR TITLE
Fix `lokf validate` in a default install

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,8 @@ classifiers = [
 ]
 # Core toolkit: the `lokf` CLI, RDF conversion, the pyoxigraph store + SPARQL,
 # the local server, and the MCP server. Deliberately excludes linkml (heavy;
-# only the artifact regenerator needs it — see the `build` extra).
+# only the artifact regenerator and `lokf validate` need it — see the `build`
+# extra).
 dependencies = [
     "rdflib>=7.0",
     "pyyaml>=6.0",
@@ -37,8 +38,9 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
-# Regenerating the LinkML-derived artifacts (`lokf-build`). Not needed to run
-# the toolkit, which reads the committed schema/context directly.
+# Regenerating the LinkML-derived artifacts (`lokf-build`) and `lokf validate`.
+# Not needed for convert/query/serve/propose/tables, which read the committed
+# schema/context directly.
 build = [
     "linkml>=1.8.5",
 ]

--- a/src/lokf/build.py
+++ b/src/lokf/build.py
@@ -226,6 +226,15 @@ def to_rdf(root: pathlib.Path, bundle: dict) -> None:
 def main() -> int:
     """Entry point for the ``lokf-build`` console script."""
     root = _find_root()
+    # generate() opens each artifact for writing *before* its generator runs, so
+    # a missing generator would truncate a committed artifact on the way to a
+    # traceback. Check once, up front.
+    if shutil.which("gen-json-schema") is None:
+        sys.exit(
+            "the LinkML generators are not on PATH: lokf-build needs the "
+            "`build` extra.\n  install:  uv sync   "
+            "(or: uv pip install 'lokf[build]')"
+        )
     generate(root)
     bundle = assemble(root)
     validate(root)

--- a/src/lokf/cli.py
+++ b/src/lokf/cli.py
@@ -139,13 +139,29 @@ def validate(
     passed, otherwise from a ``lokf.yaml`` found in the current directory or an
     ancestor, otherwise from the copy shipped inside the installed ``lokf``
     package - so a bundle needs  no schema file of its own to be validated.
-    """
-    import os
-    import subprocess
-    import tempfile
 
+    Needs LinkML, which the core install leaves out: ``pip install
+    'lokf[build]'`` (or ``uvx --from 'lokf[build]' lokf validate ...``).
+    """
     from lokf.model import load_bundle
     from lokf.schema import schema_path
+
+    # LinkML is deliberately not a core dependency (see pyproject's `build`
+    # extra), so validation is opt-in. Import the validator rather than shelling
+    # out to `linkml-validate`: an import resolves in the interpreter running
+    # lokf, while the binary only resolves if that environment's bin/ happens to
+    # be on PATH - so a correct `lokf[build]` install invoked as
+    # `.venv/bin/lokf` used to fail the same way a missing one did.
+    try:
+        from linkml.validator import validate as linkml_validate
+        from linkml.validator.report import Severity
+    except ModuleNotFoundError:
+        _err(
+            "validation needs LinkML, which the core install leaves out.\n"
+            "  install:  uv pip install 'lokf[build]'\n"
+            "  one-off:  uvx --from 'lokf[build]' lokf validate <bundle>"
+        )
+        raise typer.Exit(1)
 
     try:
         sch = schema_path(schema)
@@ -157,17 +173,14 @@ def validate(
     doc = dict(bundle.meta)
     doc["concepts"] = bundle.docs()
 
-    fd, tmp = tempfile.mkstemp(suffix=".bundle.json")
-    try:
-        with os.fdopen(fd, "w", encoding="utf-8") as f:
-            json.dump(doc, f)
-        proc = subprocess.run(
-            ["linkml-validate", "-s", str(sch), "-C", "KnowledgeBundle", tmp]
-        )
-    finally:
-        os.remove(tmp)
-    if proc.returncode != 0:
-        raise typer.Exit(proc.returncode)
+    report = linkml_validate(doc, str(sch), "KnowledgeBundle")
+    for result in report.results:
+        _err(f"[{result.severity.name}] {result.message}")
+    # Fail on ERROR/FATAL only, which is what `linkml-validate` exits non-zero
+    # on (its exit code is `1 if severity_counter[Severity.ERROR] > 0`) - a
+    # warning is reported without failing the command.
+    if any(r.severity in (Severity.ERROR, Severity.FATAL) for r in report.results):
+        raise typer.Exit(1)
     typer.echo(
         f"OK — {len(bundle.concepts)} concepts in {bundle_dir} validate "
         "against KnowledgeBundle."

--- a/src/lokf/templates/kb/README.md
+++ b/src/lokf/templates/kb/README.md
@@ -26,6 +26,7 @@ just site     # build the static site into dist/
 
 just serve    # SPARQL endpoint + graph explorer (lokf toolkit, via uvx)
 just rdf      # project the bundle to RDF / Turtle
+just validate # check the bundle against the LOKF schema
 just tables   # project the bundle to linked tables (CSV)
 ```
 

--- a/src/lokf/templates/kb/justfile
+++ b/src/lokf/templates/kb/justfile
@@ -22,6 +22,10 @@ serve:
 rdf:
     uvx --from lokf lokf convert knowledge --format ttl
 
+# Validate the bundle against the LOKF schema (needs LinkML, hence the extra)
+validate:
+    uvx --from 'lokf[build]' lokf validate knowledge
+
 # Project the bundle to linked tables (CSV under build/tables)
 tables:
     uvx --from 'lokf[tables]' lokf tables knowledge --format csv --output build/tables

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -85,6 +85,51 @@ def test_validate_reference_bundle_ok():
     assert "validate against KnowledgeBundle" in result.stdout
 
 
+def test_validate_without_linkml_hints_at_the_build_extra(monkeypatch):
+    """A lean install has no LinkML: exit 1 with an install hint, not a traceback."""
+    import sys
+
+    # `None` in sys.modules makes the `from linkml.validator import ...` raise
+    # ModuleNotFoundError, which is what a lean install raises.
+    monkeypatch.setitem(sys.modules, "linkml.validator", None)
+    result = runner.invoke(app, ["validate", str(BUNDLE)])
+    assert result.exit_code == 1
+    # `result.output`, not `.stdout`: the hint goes to stderr.
+    assert "lokf[build]" in result.output
+
+
+def test_validate_reports_a_schema_violation(tmp_path):
+    """An unknown frontmatter key fails closed, with the offending key named."""
+    (tmp_path / "index.md").write_text(
+        "---\nbase_iri: https://ex.org/kb/\ntitle: KB\n---\n", encoding="utf-8"
+    )
+    (tmp_path / "term.md").write_text(
+        "---\ntype: GlossaryTerm\ntitle: T\nseeAlso: invented\n---\n\n# T\n",
+        encoding="utf-8",
+    )
+    result = runner.invoke(app, ["validate", str(tmp_path)])
+    assert result.exit_code == 1
+    assert "[ERROR]" in result.output
+    assert "seeAlso" in result.output
+
+
+def test_validate_reports_a_warning_without_failing(monkeypatch):
+    """`linkml-validate` exits 0 unless a result is ERROR; so does this."""
+    from linkml.validator.report import Severity, ValidationResult
+
+    warning = ValidationResult(
+        type="test", severity=Severity.WARN, message="just a warning"
+    )
+    monkeypatch.setattr(
+        "linkml.validator.validate",
+        lambda *a, **kw: type("R", (), {"results": [warning]})(),
+    )
+    result = runner.invoke(app, ["validate", str(BUNDLE)])
+    assert result.exit_code == 0
+    assert "[WARN] just a warning" in result.output
+    assert "validate against KnowledgeBundle" in result.stdout
+
+
 def test_validate_missing_bundle_nonzero_exit():
     """A non-existent bundle directory is rejected before validation."""
     result = runner.invoke(app, ["validate", "does-not-exist"])

--- a/web/src/content/docs/guide/validation.mdx
+++ b/web/src/content/docs/guide/validation.mdx
@@ -21,6 +21,26 @@ flowchart LR
 validates a concept's frontmatter, or a whole bundle serialized against the
 `KnowledgeBundle` root:
 
+`lokf validate` does the assembly for you — point it at any bundle directory
+and it resolves the schema itself (a local `lokf.yaml`, else the copy inside the
+installed package):
+
+```bash
+lokf validate knowledge
+# -> OK — 2 concepts in knowledge validate against KnowledgeBundle.
+```
+
+It validates through LinkML, which the lean core install leaves out, so install
+the `build` extra to use it:
+
+```bash
+uv pip install 'lokf[build]'                          # in a project
+uvx --from 'lokf[build]' lokf validate knowledge      # one-off, no install
+```
+
+Or drive the validator directly, against an already-assembled bundle document
+or a single concept:
+
 ```bash
 # Whole bundle (assembled by `just build`)
 uv run linkml-validate -s lokf.yaml -C KnowledgeBundle examples/acme-knowledge.bundle.json

--- a/web/src/content/docs/toolkit/agents.mdx
+++ b/web/src/content/docs/toolkit/agents.mdx
@@ -69,8 +69,8 @@ That gives you:
 - the **`lokf-mcp`** stdio server for MCP clients, and
 - the bundled **skills**, reachable via `lokf skills`.
 
-The core install is lean — `typer`, `rdflib`, `pyoxigraph`, and `mcp`. Only
-regenerating the LinkML-derived artifacts needs the heavier `linkml`
-dependency, which lives behind the `lokf[build]` extra (`uv pip install
-'lokf[build]'`). See [Getting started](/getting-started/) for the
+The core install is lean — `typer`, `rdflib`, `pyoxigraph`, and `mcp`.
+Regenerating the LinkML-derived artifacts and running `lokf validate` need the
+heavier `linkml` dependency, which lives behind the `lokf[build]` extra
+(`uv pip install 'lokf[build]'`). See [Getting started](/getting-started/) for the
 from-source setup.

--- a/web/src/content/docs/toolkit/index.mdx
+++ b/web/src/content/docs/toolkit/index.mdx
@@ -55,11 +55,12 @@ Installing `lokf` gives you the CLI (`lokf`), the [MCP server](/toolkit/mcp/)
 The **core install is lean** — just `typer`, `rdflib`, `pyoxigraph`, and
 `mcp`. It reads the committed schema and context directly, so it can convert,
 query, serve, and propose without a heavy dependency tree. The one thing it
-leaves out is LinkML, needed only to **regenerate** the artifacts from
-`lokf.yaml`; that lives behind the `build` extra:
+leaves out is LinkML, needed to **regenerate** the artifacts from `lokf.yaml`
+and to run [`lokf validate`](/guide/validation/); that lives behind the
+`build` extra:
 
 ```bash
-uv pip install 'lokf[build]'   # adds linkml for lokf-build
+uv pip install 'lokf[build]'   # adds linkml for lokf-build and lokf validate
 ```
 
 `lokf --version` (or `lokf -V`) prints the installed version — a quick check


### PR DESCRIPTION
Closes #33

`lokf validate` shelled out to the `linkml-validate` binary, so a default install
ended in a full rich traceback — on the natural next step after `lokf new`.
Reproduced against the published artifact:

```
uv pip install lokf==0.5.0 && lokf new kb && cd kb && lokf validate knowledge
→ FileNotFoundError: [Errno 2] No such file or directory: 'linkml-validate'
```

### What changed

Validation now goes through `linkml.validator.validate`, behind an import guard
that says how to get the extra:

```
$ lokf validate knowledge          # lean install
validation needs LinkML, which the core install leaves out.
  install:  uv pip install 'lokf[build]'
  one-off:  uvx --from 'lokf[build]' lokf validate <bundle>
$ echo $?
1
```

**Why the Python API and not just a `FileNotFoundError` guard.** The failure is
not only "linkml missing" but "linkml not on `PATH`" — the binary resolves only
when that environment's `bin/` is on `PATH`, so a *correct* `lokf[build]` install
invoked as `.venv/bin/lokf` (or by an IDE task, or an MCP client) failed
identically, and a `FileNotFoundError` guard would have told that user to install
the extra they already had. Verified both ways:

| Install | Invocation | Before | After |
|---|---|---|---|
| core only | `lokf validate` | traceback | one-line hint, exit 1 |
| `lokf[build]` | `env -i PATH=/usr/bin:/bin .venv/bin/lokf validate` | traceback | validates, exit 0 |

An import resolves in the interpreter already running lokf. It also removes the
tempfile/subprocess/returncode dance and skips a fresh interpreter start on every
run — measured 0.16 s in-process against 0.71 s wall clock for the subprocess
path — with byte-identical closed-world messages: the `seeAlso` rejection the
reporter valued still reads the same.

**linkml stays in the `build` extra.** Measured: moving it to core takes the
install from 76 MB / 62 distributions to 151 MB / 109 — the tradeoff
`pyproject.toml`'s comment was written to avoid. So validate stays opt-in; this
turns a traceback into one actionable line. `pyproject` and the docs now name
`lokf validate` as the extra's second consumer instead of claiming only the
regenerator needs it, and the scaffolded repo gets a `just validate` recipe that
invokes it the working way.

### Second, unreported defect in the same shape

`lokf-build`'s `generate()` opens each artifact for writing **before** its
generator runs, so a missing generator truncated a committed artifact on the way
to the traceback. Verified against `origin/main`:

```
before: 240415 bytes   →   FileNotFoundError: 'gen-json-schema'   →   after: 0 bytes
```

A `shutil.which` preflight in `main()` now runs before anything is opened; the
same reproduction leaves the file at 240,415 bytes.

### Verification

- `uv run --group dev pytest` → 174 passed (172 + 2 new).
- Both repros above run end-to-end in throwaway venvs.
- New test monkeypatches `sys.modules["linkml.validator"] = None`, which is what
  a lean install raises; a second test asserts an invented frontmatter key still
  fails closed with `[ERROR]` and names the key.
