### PR TITLE
Harden the release pipeline and add the missing supply-chain controls

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,10 @@
+# Review is required for every path; these lines exist so the release-critical
+# ones are explicit once branch protection is on.
+*                       @nicholsn
+
+/.github/               @nicholsn
+/pyproject.toml         @nicholsn
+/uv.lock                @nicholsn
+
+# lokf.yaml is the single source of truth; everything generated from it follows.
+/lokf.yaml              @nicholsn

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,30 @@
+version: 2
+updates:
+  # Actions are pinned to commit SHAs, which is what makes an updater necessary:
+  # a pinned SHA never picks up a security fix on its own. Dependabot rewrites
+  # the SHA and keeps the `# vX.Y.Z` comment in step.
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    groups:
+      actions:
+        patterns: ["*"]
+
+  - package-ecosystem: uv
+    directory: /
+    schedule:
+      interval: weekly
+    groups:
+      python:
+        patterns: ["*"]
+
+  # The docs site (web/) is not shipped in the package, so its dependencies are
+  # a build-time surface only — grouped, and separate from the package's.
+  - package-ecosystem: npm
+    directory: /web
+    schedule:
+      interval: weekly
+    groups:
+      docs:
+        patterns: ["*"]

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -18,14 +18,16 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
+        with:
+          persist-credentials: false
 
       # uv drives the prebuild data steps (lokf export, gen_api_docs); Node
       # builds the Astro/Starlight site.
-      - uses: astral-sh/setup-uv@v5
+      - uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
         with:
           enable-cache: true
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: 22
           cache: npm
@@ -40,7 +42,7 @@ jobs:
           npm ci
           npm run build
 
-      - uses: actions/upload-pages-artifact@v3
+      - uses: actions/upload-pages-artifact@56afc609e74202658d3ffba0e8f6dda462b719fa # v3.0.1
         with:
           path: web/dist
 
@@ -55,5 +57,5 @@ jobs:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
     steps:
-      - uses: actions/deploy-pages@v4
+      - uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e # v4.0.5
         id: deployment

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -4,10 +4,14 @@ name: publish
 # published — no API token is stored. Configure the trusted publisher once on
 # PyPI: project "lokf", owner "nicholsn", repo "lokf", workflow "publish.yml",
 # environment "pypi".
+#
+# `release: published` is the ONLY trigger on purpose. The PyPI trusted-publisher
+# claim binds the workflow filename and the environment, not the ref, so a
+# `workflow_dispatch` of any branch would satisfy PyPI and receive a valid
+# attestation for unreviewed content. Re-publish the GitHub Release to retry.
 on:
   release:
     types: [published]
-  workflow_dispatch:
 
 permissions: {}
 
@@ -17,16 +21,20 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v5
-      - uses: astral-sh/setup-uv@v7
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
         with:
-          enable-cache: true
+          persist-credentials: false
+      # Caching is off here (setup-uv enables it by default): this job produces
+      # the released artifacts, and a cache another workflow can write is an
+      # input we don't want them to have.
+      - uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
+        with:
+          enable-cache: false
 
       # A release tag whose version was never bumped in pyproject.toml only
       # surfaces at upload time, as an opaque PyPI "400 File already exists".
       # Fail here instead, before the tests even run.
       - name: Check the release tag matches the package version
-        if: github.event_name == 'release'
         run: |
           tag="${GITHUB_REF_NAME#v}"
           packaged="$(uv version --short)"
@@ -36,12 +44,12 @@ jobs:
           fi
 
       - name: Test (gate the release)
-        run: uv run --group dev pytest -q
+        run: uv run --locked --group dev pytest -q
 
       - name: Build sdist + wheel
         run: uv build
 
-      - uses: actions/upload-artifact@v7
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: dist
           path: dist/
@@ -55,10 +63,14 @@ jobs:
     permissions:
       id-token: write # OIDC token for Trusted Publishing
     steps:
-      - uses: actions/download-artifact@v8
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: dist
           path: dist/
 
       - name: Publish to PyPI
-        uses: pypa/gh-action-pypi-publish@release/v1
+        uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33 # v1.14.2
+        with:
+          # Default is already true; stated so a default change can't silently
+          # drop PEP 740 provenance from a release.
+          attestations: true

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,57 @@
+name: test
+
+# The suite previously ran only as a release gate, so a PR could go green with
+# nothing having run it. This is what branch protection can require.
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+permissions: {}
+
+concurrency:
+  group: test-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+jobs:
+  pytest:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        # The floor and the ceiling of the supported range, per pyproject's
+        # requires-python and classifiers.
+        python-version: ["3.11", "3.12", "3.13"]
+    steps:
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
+        with:
+          persist-credentials: false
+      - uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
+        with:
+          enable-cache: true
+          python-version: ${{ matrix.python-version }}
+      # --locked fails if uv.lock has drifted from pyproject.toml, so the tests
+      # and the release build resolve the same dependency set.
+      - run: uv run --locked --group dev pytest -q
+
+  workflows:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
+        with:
+          persist-credentials: false
+      - uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
+        with:
+          enable-cache: true
+      # Guards the hardening in this directory: unpinned actions, persisted
+      # credentials, cache poisoning, template injection. Pinned so a zizmor
+      # release cannot fail an unrelated PR — bump deliberately. The token is
+      # what enables the online audits (stale/known-vulnerable action refs);
+      # without it zizmor silently runs offline and skips them.
+      - run: uvx zizmor@1.29.0 .github/workflows
+        env:
+          GH_TOKEN: ${{ github.token }}

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,54 @@
+# Security policy
+
+## Reporting a vulnerability
+
+Please report security issues **privately**, through GitHub's private
+vulnerability reporting: open
+<https://github.com/nicholsn/lokf/security/advisories/new>, or use the
+**Report a vulnerability** button under the repository's **Security** tab.
+
+Do not open a public issue for a vulnerability, and do not include exploit
+details in a pull request.
+
+LOKF is maintained by one person as an open-source side project, so please
+expect a first response in days rather than hours. There is no bounty.
+
+## Scope
+
+In scope:
+
+- The `lokf` package and CLI (`src/lokf/`) — in particular anything reachable by
+  parsing an untrusted bundle: `lokf convert`, `lokf query`, `lokf validate`,
+  `lokf propose`, the `lokf serve` HTTP surface, and the `lokf-mcp` server.
+- The release pipeline (`.github/workflows/publish.yml`) and the published
+  artifacts on PyPI.
+- The scaffold (`lokf new`) and the agent skills it installs, where they could
+  cause an agent to execute something the author did not intend.
+
+Out of scope:
+
+- The documentation site (`web/`), which serves static content only.
+- A bundle that is merely *wrong* — validation is closed-world by design, but a
+  producer's incorrect data is a data problem, not a vulnerability.
+
+## What LOKF assumes about a bundle
+
+A LOKF bundle is markdown plus YAML frontmatter, and consumers are specified to
+be permissive (unknown keys and types MUST NOT cause rejection). Treat a bundle
+from a third party as untrusted input: frontmatter is read with
+`yaml.safe_load` (and ruamel's round-trip loader where `lokf propose --apply`
+rewrites it), never a loader that constructs arbitrary objects; and a concept's
+`resource`, `endpoint`, and relation targets are identifiers, not instructions
+to fetch or execute. If you build an agent on
+top of LOKF, the same applies to a bundle's prose — `AttestedComputation`
+carries a *sanctioned* recipe precisely so an agent does not have to trust
+free-form text.
+
+## Supply chain
+
+- PyPI releases use Trusted Publishing (OIDC); no long-lived API token exists.
+- Releases carry PEP 740 attestations, verifiable at
+  `https://pypi.org/integrity/lokf/<version>/<file>/provenance`.
+- GitHub Actions are pinned to commit SHAs; Dependabot updates them weekly.
+- `uv.lock` is committed, and CI runs with `--locked` so the tested and released
+  dependency sets are the same.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -78,5 +78,7 @@ exclude = [
 ]
 
 [build-system]
-requires = ["hatchling"]
+# Bounded so a hatchling major can't change what the release build produces
+# without a deliberate bump.
+requires = ["hatchling>=1.27,<2"]
 build-backend = "hatchling.build"


### PR DESCRIPTION
Closes #20

`zizmor .github/workflows` reported **19 findings on `origin/main`** (11 high, 2
medium, 6 suppressed). It now reports none.

```
$ uvx zizmor .github/workflows          # main
19 findings (6 suppressed, 3 unsafe fixes): 0 informational, 0 low, 2 medium, 11 high
$ uvx zizmor .github/workflows          # this branch
No findings to report. Good job! (8 suppressed)
```

### `workflow_dispatch` could publish arbitrary content from any ref

The highest-severity gap, and not one the issue names. The tag/version guard was
gated on `if: github.event_name == 'release'`, so a manual dispatch skipped it —
and the `pypi` environment has no reviewers and no deployment-branch policy
(`{"can_admins_bypass":true,"deployment_branch_policy":null,"protection_rules":[]}`).

The PyPI trusted-publisher claim binds the **workflow filename and environment,
not the ref**. I checked this against the real 0.5.0 attestation: the sigstore
cert carries `…/publish.yml@refs/tags/v0.5.0` and
`repo:nicholsn/lokf:environment:pypi`, and nothing that pins *which* ref may
publish. So a dispatch of any branch would have satisfied PyPI and received a
valid PEP 740 attestation for unreviewed content.

`release: published` is now the only trigger, and the guard is unconditional.

### No action was pinned

Ten floating refs. The worst is `pypa/gh-action-pypi-publish@release/v1` — a
mutable **branch** on a third-party action, in the one job holding
`id-token: write` and the publishing identity. All ten are now commit SHAs with
the resolved tag in a trailing comment.

### Cache poisoning on the release build

`setup-uv` caches by default, so the job producing the released artifacts
restored a cache other workflows can write. Off explicitly there; kept for docs
and tests, which ship nothing.

### Also

- `persist-credentials: false` on every checkout.
- `uv run --locked` on the release gate, so it cannot resolve outside `uv.lock`.
- Build backend bounded to `hatchling>=1.27,<2`.
- `attestations: true` stated rather than inherited — verified it is the default
  at that SHA, so this only guards against a default change.
- `docs.yml` moved off the Node-20 action majors `publish.yml` left behind.

### New files

- **`test.yml`** — the suite ran *only* as a release gate, so a PR could go green
  without anything having run it. Now pytest across 3.11/3.12/3.13 plus zizmor
  over the workflows. This is what branch protection can require.
- **`dependabot.yml`** — pinning to SHAs is what makes an updater *necessary*: a
  pinned SHA never picks up a security fix on its own.
- **`SECURITY.md`** — there was no reporting path at all, the dead-channel failure
  mode linkml/linkml#3623 documents. It also states what LOKF assumes about an
  untrusted bundle, since agent ingestion is the issue's stated worry.
- **`CODEOWNERS`** — explicit on the release-critical paths.

### Only you can do these (all confirmed by API)

- [ ] `main` has no protection and no rulesets; `sha_pinning_required` is false.
- [ ] The `pypi` environment has no reviewers and no deployment-branch policy —
      restricting it to tags is the other half of the `workflow_dispatch` fix.
- [ ] Dependabot alerts are disabled (`/vulnerability-alerts` → 404), so the
      config above only opens version PRs until you enable them.
- [ ] Private vulnerability reporting is off, which leaves `SECURITY.md`'s link
      dead — **worth enabling before this merges.**

Deliberately not included: `dependency-review-action` needs the dependency graph
and would go red until the settings above are on; CodeQL is mostly noise on a
package this size; OpenSSF Scorecard is worth adding once there is branch
protection to score.

lokf is already ahead of linkml/linkml#3623's checklist on trusted publishing,
attestations and `permissions: {}`; this closes the gap on hash pinning,
Dependabot and `SECURITY.md`.
