### PR TITLE
Make what `lokf new` emits match the repo it emits it into

### DIFF
--- a/src/lokf/skills/enrich-relations/SKILL.md
+++ b/src/lokf/skills/enrich-relations/SKILL.md
@@ -32,7 +32,7 @@ overwrites an existing frontmatter relation.
 1. **Dry-run first (no writes).** Review every proposal as a table:
 
    ```bash
-   lokf propose examples/acme-knowledge
+   lokf propose <bundle>
    ```
 
    Columns: `SOURCE`, `LINK`, `PREDICATE` (the CURIE it would write), `CONF`,
@@ -43,14 +43,14 @@ overwrites an existing frontmatter relation.
    confidence to decide a threshold:
 
    ```bash
-   lokf propose examples/acme-knowledge --json
+   lokf propose <bundle> --json
    ```
 
 3. **Set a confidence floor** to drop weak guesses. Inspect the distribution,
    then filter:
 
    ```bash
-   lokf propose examples/acme-knowledge --min-confidence 0.6
+   lokf propose <bundle> --min-confidence 0.6
    ```
 
 4. **Apply the accepted proposals.** `--apply` writes each surviving proposal
@@ -58,7 +58,7 @@ overwrites an existing frontmatter relation.
    only trusted edges land:
 
    ```bash
-   lokf propose examples/acme-knowledge --min-confidence 0.6 --apply
+   lokf propose <bundle> --min-confidence 0.6 --apply
    ```
 
    The command reports `wrote <relation> -> <target> in <file>` per edge and a
@@ -73,7 +73,7 @@ overwrites an existing frontmatter relation.
    are present:
 
    ```bash
-   lokf convert examples/acme-knowledge --format ttl | grep -E "prov:|dcterms:|schema:"
+   lokf convert <bundle> --format ttl | grep -E "prov:|dcterms:|schema:"
    ```
 
    Re-running `lokf propose` (dry) should now show fewer proposals, since

--- a/src/lokf/skills/publish-graph/SKILL.md
+++ b/src/lokf/skills/publish-graph/SKILL.md
@@ -22,7 +22,7 @@ out to `lokf query`.
 ## Start the server
 
 ```bash
-lokf serve examples/acme-knowledge --host 127.0.0.1 --port 8000
+lokf serve <bundle> --host 127.0.0.1 --port 8000
 ```
 
 Defaults are host `127.0.0.1`, port `8000`. The process runs in the foreground;
@@ -48,7 +48,7 @@ GET with the query URL-encoded, requesting SPARQL JSON results:
 
 ```bash
 curl -sG http://127.0.0.1:8000/sparql \
-  --data-urlencode 'query=SELECT ?s ?title WHERE { ?s a lokf:Metric ; dcterms:title ?title }' \
+  --data-urlencode 'query=SELECT ?s ?title WHERE { ?s a lokf:Metric ; schema:name ?title }' \
   -H 'Accept: application/sparql-results+json'
 ```
 

--- a/src/lokf/skills/query-knowledge-base/SKILL.md
+++ b/src/lokf/skills/query-knowledge-base/SKILL.md
@@ -40,19 +40,20 @@ CONSTRUCT/DESCRIBE emits `ttl` (or another RDF format). Example:
 
 ## Worked patterns
 
-Run these against `examples/acme-knowledge`.
+`<bundle>` is the bundle directory you are working in — `knowledge/` in a
+repo scaffolded by `lokf new`.
 
 **1. Everything of a type** — list all metrics with their titles:
 
 ```bash
-lokf query examples/acme-knowledge \
-  "SELECT ?s ?title WHERE { ?s a lokf:Metric ; dcterms:title ?title }"
+lokf query <bundle> \
+  "SELECT ?s ?title WHERE { ?s a lokf:Metric ; schema:name ?title }"
 ```
 
 **2. Follow a relation** — what each concept depends on:
 
 ```bash
-lokf query examples/acme-knowledge \
+lokf query <bundle> \
   "SELECT ?s ?target WHERE { ?s dcterms:requires ?target }"
 ```
 
@@ -63,7 +64,7 @@ metric's `measures`.)
 **3. Counts / aggregation** — how many concepts of each type:
 
 ```bash
-lokf query examples/acme-knowledge \
+lokf query <bundle> \
   "SELECT ?type (COUNT(?s) AS ?n) WHERE { ?s a ?type } GROUP BY ?type ORDER BY DESC(?n)"
 ```
 
@@ -71,17 +72,17 @@ lokf query examples/acme-knowledge \
 `derivedFrom`, and check existence with ASK:
 
 ```bash
-lokf query examples/acme-knowledge \
+lokf query <bundle> \
   "SELECT ?metric ?table WHERE { ?metric a lokf:Metric ; prov:wasDerivedFrom ?table }"
 
-lokf query examples/acme-knowledge \
+lokf query <bundle> \
   "ASK { ?m a lokf:Metric ; prov:wasDerivedFrom ?t . ?t a lokf:Table }"
 ```
 
 **5. Extract a subgraph** — CONSTRUCT one concept's outgoing edges as Turtle:
 
 ```bash
-lokf query examples/acme-knowledge \
+lokf query <bundle> \
   "CONSTRUCT { ?s ?p ?o } WHERE { ?s a lokf:Metric ; ?p ?o }" --format ttl
 ```
 

--- a/src/lokf/skills/scaffold-knowledge-base/SKILL.md
+++ b/src/lokf/skills/scaffold-knowledge-base/SKILL.md
@@ -56,8 +56,11 @@ the repository, then hands off to `author-concept` / `build-knowledge-base` /
    `/graph` browser); explore with the toolkit via `just serve`; get the
    tabular projection with `just tables`.
 
-5. **Publish.** Confirm `base_iri` in `knowledge/index.md` and `site`/`base` in
-   `astro.config.mjs` match the real URL, run `just setup` once and commit
+5. **Publish.** Confirm the base IRI matches the real URL everywhere it is
+   held — `base_iri` in `knowledge/index.md`, `site`/`base` (and the
+   `remarkLokfLinks` `base`) in `astro.config.mjs`, `BASE_IRI` in
+   `src/lib/lokf.ts`, and the starter concept's `measures:` cross-reference —
+   then run `just setup` once and commit
    `package-lock.json`, push to GitHub, and set **Settings → Pages → Source**
    to **GitHub Actions**. The `pages` workflow builds and deploys on every
    push to `main`.

--- a/src/lokf/templates/kb/README.md
+++ b/src/lokf/templates/kb/README.md
@@ -35,9 +35,19 @@ The `lokf` recipes use [`uvx`](https://docs.astral.sh/uv/), so they only need
 
 ## Publish to GitHub Pages
 
-1. Set `base_iri` in `knowledge/index.md` — and `site`/`base` in
-   `astro.config.mjs` — to the URL you will publish at (already done if you
-   passed `--base-iri` to `lokf new`).
+1. Point the repo at the URL you will publish at. `lokf new --base-iri
+   https://you.example/my-kb/` does this for you, so if you scaffolded without
+   the flag the simplest fix is to re-scaffold with it. Set by hand, it lives in
+   four files:
+
+   - `knowledge/index.md` — `base_iri`
+   - `astro.config.mjs` — `site`, `base`, and the `base` passed to `remarkLokfLinks`
+   - `src/lib/lokf.ts` — `BASE_IRI`
+   - `knowledge/metrics/weekly-active-users.md` — the `measures:` cross-reference
+
+   Missing one is silent: a concept carrying an absolute `id` never reaches the
+   `BASE_IRI` fallback, so the graph looks right until a concept without one —
+   or a bundle-relative reference — mints an IRI that does not match the rest.
 2. Push to GitHub; in **Settings → Pages**, set the source to **GitHub Actions**.
 3. The `pages` workflow builds the site and publishes it on every push to `main`.
 

--- a/src/lokf/templates/kb/src/styles/global.css
+++ b/src/lokf/templates/kb/src/styles/global.css
@@ -60,6 +60,12 @@ body {
 
 a { color: var(--accent-ink); text-decoration: none; text-underline-offset: 3px; }
 a:hover { text-decoration: underline; }
+/* Colour alone can't mark a link inside a sentence (WCAG 1.4.1): --accent-ink
+   is 2.36:1 against body text in light mode and 1.63:1 in dark, both under the
+   3:1 a colour-only cue would need. Underline the in-prose anchors; the nav,
+   cards and pill links keep the underline-free look — they are large, plainly
+   interactive targets that don't rely on colour to read as links. */
+article a, .tagline a, .site-footer a { text-decoration: underline; }
 :focus-visible { outline: 2px solid var(--accent); outline-offset: 2px; border-radius: 3px; }
 
 h1, h2, h3 {
@@ -205,8 +211,9 @@ article :is(h2, h3) { scroll-margin-top: 5rem; }
   padding: 1.8rem 1.5rem; text-align: center; color: var(--muted); font-size: 0.86rem;
   background: var(--surface);
 }
-.site-footer a { color: var(--muted); font-weight: 500; }
-.site-footer a:hover { color: var(--accent-ink); }
+/* --muted here would be the footer text's own colour: 1.00:1. */
+.site-footer a { color: var(--accent-ink); font-weight: 500; }
+.site-footer a:hover { color: var(--accent); }
 
 @media (max-width: 34rem) {
   body { font-size: 17px; }

--- a/tests/test_scaffold.py
+++ b/tests/test_scaffold.py
@@ -102,3 +102,54 @@ def test_template_handles_real_authoring(tmp_path):
     assert (root / "remark-lokf-links.mjs").exists()
     lib = (root / "src/lib/lokf.ts").read_text()
     assert "resolveRef" in lib                                # relative relation targets
+
+
+def test_scaffolded_skills_point_at_a_path_that_exists(tmp_path):
+    """The installed skills must not send an agent at `examples/acme-knowledge`.
+
+    That is this repo's own bundle; a scaffolded repo's is `knowledge/`.
+    """
+    root = scaffold.new("kb", path=tmp_path)
+    skills = sorted((root / ".claude" / "skills").glob("*/SKILL.md"))
+    assert skills
+    for md in skills:
+        assert "examples/acme-knowledge" not in md.read_text(), md
+    assert (root / "knowledge").is_dir()
+
+
+def test_scaffolded_readme_names_every_base_iri_holder(tmp_path):
+    """The publish step must name all four files that hold the base IRI.
+
+    Naming only two leaves `BASE_IRI` and the starter concept's cross-reference
+    on `example.org`, which fails silently.
+    """
+    root = scaffold.new("kb", path=tmp_path)
+    readme = (root / "README.md").read_text()
+    for held_in in [
+        "knowledge/index.md",
+        "astro.config.mjs",
+        "src/lib/lokf.ts",
+        "knowledge/metrics/weekly-active-users.md",
+    ]:
+        assert held_in in readme, held_in
+
+
+def test_explicit_base_iri_leaves_no_placeholder_domain(tmp_path):
+    """--base-iri must reach every holder: no `example.org` left anywhere."""
+    root = scaffold.new("kb", path=tmp_path, base_iri="https://you.example/mykb/")
+    for f in root.rglob("*"):
+        if f.is_file() and ".claude" not in f.parts:
+            assert "example.org" not in f.read_text(), f
+
+
+def test_prose_links_carry_a_non_colour_cue(tmp_path):
+    """WCAG 1.4.1: an in-sentence link can't be marked by colour alone.
+
+    --accent-ink is under 3:1 against body text in both themes, so the prose
+    anchors are underlined, and footer links no longer resolve to the footer
+    text's own token (1.00:1).
+    """
+    css = (scaffold.new("kb", path=tmp_path) / "src/styles/global.css").read_text()
+    assert "article a, .tagline a, .site-footer a { text-decoration: underline; }" in css
+    assert ".site-footer a { color: var(--muted)" not in css
+

--- a/tests/test_skills.py
+++ b/tests/test_skills.py
@@ -56,3 +56,20 @@ def test_install_reruns_without_error(tmp_path):
     assert sorted(p.parent.name for p in dest.glob("*/SKILL.md")) == sorted(
         SKILL_NAMES
     )
+
+
+def test_packaged_skills_name_no_repo_specific_bundle():
+    """No skill hardcodes this repo's own bundle path.
+
+    `lokf skills install` drops these into any project, and `lokf new` into a
+    scaffolded repo whose bundle is `knowledge/` — neither has this repo's
+    `examples/acme-knowledge`, so the skills use the `<bundle>` placeholder
+    they already use elsewhere. This checks the path only; it does not run the
+    commands.
+    """
+    for skill in sorted(skills_dir().iterdir()):
+        md = skill / "SKILL.md"
+        if not md.is_file():
+            continue
+        assert "examples/acme-knowledge" not in md.read_text(encoding="utf-8"), md
+


### PR DESCRIPTION
Closes #34
Closes #35
Closes #36

> **Stacked on #37** (`fix/validate-linkml-guard`) — review/merge that first; this
> branch's own diff is `git diff fix/validate-linkml-guard...fix/scaffold-output-accuracy`.

Three defects in what `lokf new` emits, all from the same fresh-install sweep,
all found by scaffolding a repo and reading what it tells you to do.

### The installed agent skills pointed at a path that does not exist (#34)

Three of the six skills spelled 13 example commands against
`examples/acme-knowledge` — this repository's own bundle, which the scaffold does
not create. They now use the `<bundle>` placeholder the other four skills already
use, including twice in the very file that then hardcoded acme six lines later.

That is the issue's **third** option rather than the scaffold-time rewrite
suggested in the comments, for two reasons:

- `lokf skills install --dest` drops these skills into *any* project, so a
  scaffold-only rewrite leaves every other consumer broken.
- A literal rewrite to `knowledge` gives commands that run but demonstrate
  nothing: against the 2-concept starter, `lokf propose knowledge` prints
  `no proposals.` and the provenance query returns no results — which makes
  `enrich-relations`' whole dry-run/apply loop vacuous.

```
$ lokf new demo && grep -rho 'examples/acme-knowledge' demo/.claude/skills/ | wc -l
0
```

### Prose links were distinguished by colour alone; footer links by nothing (#35)

`--accent-ink` measures **2.36:1** against body text in light mode and
**1.63:1** in dark — both under the 3:1 WCAG 1.4.1 asks when colour is the only
cue. And `.site-footer a` resolved to `--muted`, the footer text's own token, so
the four links in every page's footer sat at exactly **1.00:1** with
`font-weight: 500` as the only persistent difference.

In-prose anchors are underlined now — `global.css` already carried
`text-underline-offset: 3px`, so the look was pre-tuned for it — and footer links
get their own colour. Verified in a built scaffolded site, light and dark:

| | before | after |
|---|---|---|
| footer link vs footer text | `#6d675d` vs `#6d675d`, no underline | `#8f3d16` vs `#6d675d`, underlined |
| prose link | colour only | underlined |
| nav / cards / pill links | no underline | unchanged |

Scoped to `article a, .tagline a, .site-footer a` rather than the reported
`p a, li a`: the latter would have underlined the "Visit resource ↗" pill, which
is a `<p class="lede-links">` at `[...slug].astro:44`. The relations panel is
left as designed — a labelled list where every item is a link, not running prose.

### The base-IRI step named two of the four files that hold it (#36)

`--base-iri` does set all of them, so this is prose only — but following the
manual path left `BASE_IRI` in `src/lib/lokf.ts` and the starter concept's
`measures:` cross-reference on `example.org`. Silent, because a concept carrying
an absolute `id` never reaches the `BASE_IRI` fallback: the graph looks right
until a concept without one mints a mismatched IRI.

The step now names all four. The issue undercounts too — `astro.config.mjs` holds
the value **three** times, including the `remarkLokfLinks` option — and the same
undercount is fixed in the `scaffold-knowledge-base` skill, which `lokf new` also
installs, so an agent was reading the identical wrong instruction.

### Verification

`uv run --group dev pytest` → 179 passed. Five new tests scaffold a repo and
assert what a reader would check: no skill names a nonexistent path, the README
names every base-IRI holder, `--base-iri` leaves no `example.org` anywhere, and
prose links carry a non-colour cue. The scaffolded site was built with
`npm ci && npm run build` and inspected in the browser in both colour schemes.
