### PR TITLE
Finish the Apache-2.0 move: package NOTICE, name the holder, state the split

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,6 +20,10 @@ A few essentials:
 - **Reuse public vocabulary.** New types and fields should map to established
   ontology terms (schema.org, DCAT, PROV-O, SKOS, W3C ORG, …) rather than mint
   new ones — reuse is the whole point of LOKF.
+- **Licensing (inbound = outbound).** Contributions to the toolkit (`src/`,
+  `tests/`, the build tooling) are accepted under the Apache License 2.0;
+  contributions to the specification and vocabulary (`SPEC.md`, `lokf.yaml`)
+  under CC-BY-4.0. See the [License section of the README](README.md#license).
 - **Responsible AI use.** LOKF is built with AI assistance. Please review the
   [AI Covenant](AI_COVENANT.md): you own everything you submit, and AI is never
   credited as a commit co-author.

--- a/NOTICE
+++ b/NOTICE
@@ -1,3 +1,21 @@
+LOKF (Linked Open Knowledge Format)
+Copyright 2026 Nolan Nichols
+
+Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+The specification (SPEC.md), the LinkML schema (lokf.yaml), and the data
+artifacts generated from that schema (lokf.context.jsonld, lokf.schema.json,
+lokf.shacl.ttl, lokf.owl.ttl, lokf.sql) are licensed under CC-BY-4.0.
+
+The generated Python bindings (src/lokf/datamodel.py) are part of this package
+and ship under Apache-2.0, even though their header comment transcribes the
+schema's own CC-BY-4.0 `license:` value. Wherever you see CC-BY-4.0 named
+inside a generated file, it is the schema's license, not the package's.
+
 "Open Knowledge Format" and "OKF" refer to the format published by Google Cloud
 (github.com/GoogleCloudPlatform/knowledge-catalog). LOKF is an independent,
 unaffiliated profile built upon it.
+
+This product bundles Cytoscape.js (src/lokf/static/cytoscape.min.js),
+Copyright (c) 2016-2024 The Cytoscape Consortium, licensed under the MIT
+License. Its full license header is retained in that file.

--- a/README.md
+++ b/README.md
@@ -219,7 +219,20 @@ by a human. See [CONTRIBUTING.md](CONTRIBUTING.md) to get involved.
 
 ## License
 
-Software licensed under Apache License 2.0
+The **software** — the `lokf` toolkit in `src/`, the tests, and the build
+tooling — is licensed under the Apache License 2.0. See [`LICENSE`](./LICENSE)
+and [`NOTICE`](./NOTICE).
 
-The [SPEC](./SPEC.md) and [SCHEMA](./lokf.yaml) are licensed under CC-BY-4.0.
+The **specification and vocabulary** — [`SPEC.md`](./SPEC.md), the LinkML schema
+[`lokf.yaml`](./lokf.yaml), and the artifacts generated from it
+(`lokf.context.jsonld`, `lokf.schema.json`, `lokf.shacl.ttl`, `lokf.owl.ttl`,
+`lokf.sql`) — are licensed under
+[CC-BY-4.0](https://creativecommons.org/licenses/by/4.0/).
+
+`src/lokf/datamodel.py` is generated too, but it is Python that ships *in* the
+package, so it is Apache-2.0 like the rest of `src/`. Its header comment — and
+`lokf.owl.ttl`'s `dcterms:license` — transcribe `lokf.yaml`'s own `license:`
+key, so wherever CC-BY-4.0 appears inside a generated file it is the schema's
+license, not the package's. The published package declares `Apache-2.0`, which
+is the license of the code you install.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ version = "0.5.0"
 description = "Linked Open Knowledge Format (LOKF) — a semantic profile of Google's Open Knowledge Format, defined once in LinkML"
 readme = "README.md"
 license = "Apache-2.0"
-license-files = ["LICENSE"]
+license-files = ["LICENSE", "NOTICE"]
 authors = [{ name = "Nolan Nichols" }]
 requires-python = ">=3.10"
 keywords = ["linkml", "json-ld", "rdf", "knowledge-graph", "okf", "dcat", "prov", "sparql", "mcp"]

--- a/tests/test_packaging.py
+++ b/tests/test_packaging.py
@@ -1,0 +1,41 @@
+"""Packaging metadata: the license the project declares and the files it ships.
+
+Nothing asserted any of this before, which is how a CC-BY-4.0 LICENSE for
+software survived, and how a NOTICE file could be added and then left out of
+the wheel.
+
+Asserted against the installed distribution's metadata rather than by parsing
+pyproject.toml, so this tests what actually ships — and needs no TOML parser
+(``tomllib`` is 3.11+, and the package supports 3.10).
+"""
+from __future__ import annotations
+
+import pathlib
+from importlib.metadata import metadata
+
+ROOT = pathlib.Path(__file__).resolve().parents[1]
+META = metadata("lokf")
+
+
+def test_declared_license_is_apache_2_0():
+    """The distribution declares an OSI-approved license, not a CC one."""
+    assert META["License-Expression"] == "Apache-2.0"
+
+
+def test_license_file_is_apache_2_0():
+    """LICENSE is the Apache text — the assertion that catches a CC-BY LICENSE."""
+    text = (ROOT / "LICENSE").read_text(encoding="utf-8")
+    assert "Apache License" in text
+    assert "Version 2.0, January 2004" in text
+    assert "creativecommons.org" not in text
+
+
+def test_notice_is_packaged():
+    """Apache-2.0 §4(d) only works if NOTICE reaches the installed artifact."""
+    assert set(META.get_all("License-File")) == {"LICENSE", "NOTICE"}
+    assert (ROOT / "NOTICE").is_file()
+
+
+def test_notice_names_a_copyright_holder():
+    """The Apache grant needs a named owner; LICENSE's appendix is boilerplate."""
+    assert "Copyright" in (ROOT / "NOTICE").read_text(encoding="utf-8")

--- a/web/src/content/docs/contributing.md
+++ b/web/src/content/docs/contributing.md
@@ -70,3 +70,17 @@ The full policy is the
 [AI Covenant](https://github.com/nicholsn/lokf/blob/main/AI_COVENANT.md),
 adapted from the
 [LinkML AI Covenant](https://github.com/linkml/linkml/blob/main/AI_COVENANT.md).
+
+## License
+
+Contributions follow the project's two-license split (inbound = outbound):
+
+- The **software** — the `lokf` toolkit, the tests, and the build tooling — is
+  licensed under the [Apache License 2.0](https://github.com/nicholsn/lokf/blob/main/LICENSE).
+- The **specification and vocabulary** — `SPEC.md`, the LinkML schema
+  `lokf.yaml`, and the artifacts generated from it — are licensed under
+  [CC-BY-4.0](https://creativecommons.org/licenses/by/4.0/).
+
+The published package declares `Apache-2.0`; the CC-BY-4.0 `license:` value you
+will see inside `lokf.yaml` and its generated headers is the schema's own
+license, not the package's.


### PR DESCRIPTION
Closes #26

> **Stacked on #40** (`chore/python-310-support`) — merge that first.

PR #27 did the substantive thing this issue asked for, and did it correctly:
`LICENSE` is the byte-exact Apache 2.0 text, `pyproject` declares `Apache-2.0`,
and the built wheel emits `License-Expression: Apache-2.0`. Three loose ends were
left, all verified against a wheel built from `main`.

### 1. NOTICE never reached the wheel

`license-files = ["LICENSE"]` meant the dist-info carried only
`licenses/LICENSE`, and METADATA had a single `License-File:`. The **sdist** did
carry NOTICE, so the two artifacts disagreed — and the one everyone installs was
the one missing it, which defeats the Apache §4(d) convention #27 added the file
for.

```
# main
lokf-0.5.0.dist-info/licenses/LICENSE      License-File: LICENSE
# this branch
lokf-0.5.0.dist-info/licenses/LICENSE      License-File: LICENSE
lokf-0.5.0.dist-info/licenses/NOTICE       License-File: NOTICE
```

### 2. No copyright holder was asserted anywhere

`git grep -i copyright` outside `LICENSE` and the vendored `cytoscape.min.js`
returned nothing. `LICENSE:189` is still the unfilled
`Copyright [yyyy] [name of copyright owner]` appendix template — correct
boilerplate, left alone. NOTICE now names the holder, and also attributes the
bundled Cytoscape.js (MIT; its header is retained in the file).

### 3. The dual-license split lived in three lines of README and nowhere else

It never said what covers the five generated artifacts — one of which asserts
CC-BY-4.0 in-band (`lokf.owl.ttl`'s `dcterms:license`) — and `CONTRIBUTING.md`
had no licensing statement at all, so a contributor editing `lokf.yaml` versus
`src/` had no inbound terms. The docs site stated no license anywhere.

The README section now allocates every path and explains why `lokf.yaml` and
`src/lokf/datamodel.py` carry CC-BY-4.0 headers inside an Apache-2.0
distribution (it is the *schema's* license, not the package's); CONTRIBUTING
states inbound = outbound; the docs site has a License section.

### Guarded

`tests/test_packaging.py` asserts the declared license, that `LICENSE` is the
Apache text and contains no `creativecommons.org`, that NOTICE is packaged, and
that it names a holder. Nothing asserted any licensing fact before — which is how
a CC-BY-4.0 LICENSE for software survived to this issue, and how NOTICE could be
added and dropped from the wheel in the same PR. Asserted against the installed
distribution's metadata rather than by parsing `pyproject.toml`, so it tests what
actually ships and needs no `tomllib` (3.11+, and the stack below supports 3.10).

### Deliberately not done

Widening the SPDX expression to `Apache-2.0 AND CC-BY-4.0`. It is arguably more
accurate for a distribution that ships `src/lokf/data/lokf.yaml`, but CC-BY-4.0
is not OSI-approved, so it would make PyPI and downstream scanners flag the
package as partly non-OSI — the exact outcome this issue was filed to avoid.
`lokf.yaml`'s own `license:` key is also left alone: changing it would regenerate
three artifacts and contradict the split.
