### PR TITLE
Answer ASK queries in `lokf query`'s default table format

### DIFF
--- a/src/lokf/cli.py
+++ b/src/lokf/cli.py
@@ -247,6 +247,10 @@ def query(
         if form in ("construct", "describe"):
             fmt = "ttl" if format == "table" else format
             typer.echo(store.construct(sparql, fmt=fmt), nl=False)
+        elif format == "table" and form == "ask":
+            # An ASK answer is a boolean, not rows: `select` would reach for
+            # `.variables` on it and fail.
+            typer.echo("true" if store.ask(sparql) else "false")
         elif format == "table":
             _print_rows(store.select(sparql))
         else:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -116,6 +116,22 @@ def test_query_construct_turtle():
     assert "wasDerivedFrom" in result.stdout or "prov:" in result.stdout
 
 
+def test_query_ask_in_the_default_table_format():
+    """An ASK answer is a boolean; the default format used to crash on it."""
+    result = runner.invoke(app, ["query", str(BUNDLE), "ASK { ?s ?p ?o }"])
+    assert result.exit_code == 0, result.output
+    assert result.stdout.strip() == "true"
+
+
+def test_query_ask_false_still_exits_zero():
+    """A false answer is an answer, not a failure."""
+    result = runner.invoke(
+        app, ["query", str(BUNDLE), "ASK { ?s a lokf:NoSuchClass }"]
+    )
+    assert result.exit_code == 0
+    assert result.stdout.strip() == "false"
+
+
 def test_query_malformed_sparql_nonzero_exit():
     """A malformed SPARQL query exits non-zero."""
     result = runner.invoke(app, ["query", str(BUNDLE), "SELEC broken"])


### PR DESCRIPTION
Found while fixing the shipped agent skills in #41 — not tied to an open issue.

`lokf query <bundle> "ASK { ... }"` failed with an internal error:

```
$ lokf query examples/acme-knowledge "ASK { ?s ?p ?o }"
query failed: 'pyoxigraph.QueryBoolean' object has no attribute 'variables'
$ echo $?
1
```

`query()` special-cased CONSTRUCT/DESCRIBE and sent everything else to
`store.select()`, which reaches for `result.variables` — an attribute a boolean
result doesn't have. **Only the default `table` format was affected**;
`--format json|csv|tsv` all answered correctly, which is why it went unnoticed.

The pieces were already there and simply unused: `query_form()` already returns
`"ask"` and `GraphStore.ask()` already exists, and the server and the MCP tool
both use them. The CLI now does too:

```
$ lokf query examples/acme-knowledge "ASK { ?s ?p ?o }"
true
$ lokf query examples/acme-knowledge "ASK { ?s a lokf:NoSuchClass }"
false
$ echo $?
0
```

Exit 0 either way — a false answer is an answer, not a failure. That matches
`--format json`, which already returned `{"head":{},"boolean":true}` and exit 0.

### Why it's worth a PR

The shipped `query-knowledge-base` skill advertises "`--format table` (default,
human), `json`, `csv`, `tsv` for SELECT/ASK" and then gives a bare ASK example
with no `--format`, so an agent following the skill hit the traceback. #41 fixes
the *path* in those examples; this makes the command they name actually work.

No test covered ASK through the CLI — ASK was only exercised via `store.ask()`,
the server and the MCP tool. Two tests now cover both the true and false cases,
and both fail on `main`.
